### PR TITLE
bugfix/metric_hyperplane_partitioner_unique_selectors

### DIFF
--- a/examples/dhnsw_ascii_levenshtein.cpp
+++ b/examples/dhnsw_ascii_levenshtein.cpp
@@ -10,6 +10,7 @@
 #include <saltatlas/dhnsw/detail/utility.hpp>
 #include <saltatlas/dhnsw/dhnsw.hpp>
 #include <saltatlas/partitioner/metric_hyperplane_partitioner.hpp>
+#include <saltatlas/partitioner/voronoi_partitioner.hpp>
 
 #include <ygm/comm.hpp>
 #include <ygm/container/map.hpp>
@@ -261,6 +262,8 @@ int main(int argc, char** argv) {
 
   saltatlas::metric_hyperplane_partitioner<dist_t, index_t, point_t>
       fuzzy_partitioner(world, fuzzy_leven_space);
+  // saltatlas::voronoi_partitioner<dist_t, index_t, point_t> fuzzy_partitioner(
+  // world, fuzzy_leven_space);
 
   ygm::container::pair_bag<index_t, point_t> bag_data(world);
   size_t                                     local_counter;

--- a/include/saltatlas/dhnsw/detail/dist_index.hpp
+++ b/include/saltatlas/dhnsw/detail/dist_index.hpp
@@ -83,6 +83,7 @@ class dhnsw_impl {
   void add_data_point_to_insertion_queue(const index_t index, const point_t &v,
                                          const index_vec_t &closest_seeds) {
     auto insertion_cell = closest_seeds[0];
+    ASSERT_RELEASE(insertion_cell < m_num_cells);
     m_comm->async(
         cell_owner(insertion_cell),
         [](auto mbox, ygm::ygm_ptr<dhnsw_impl> pthis, index_t index,
@@ -99,13 +100,12 @@ class dhnsw_impl {
   void initialize_hnsw() {
     // Initialize HNSW structures
     for (int i = 0; i < num_local_cells(); ++i) {
+      ASSERT_RELEASE(m_cell_add_vec[i].size() > 0);
+
       hnswlib::HierarchicalNSW<dist_t> *hnsw =
           new hnswlib::HierarchicalNSW<dist_t>(
               m_metric_space_ptr, m_cell_add_vec[i].size(), 16, 200, 1);
       m_voronoi_cell_hnsw.push_back(hnsw);
-
-      // m_comm->cout() << "Initializing local HNSW with "
-      //<< m_cell_add_vec[i].size() << " points" << std::endl;
 
       // Add data points to HNSW
       set_cell_add_vec_ordering(m_cell_add_vec[i]);

--- a/include/saltatlas/partitioner/voronoi_partitioner.hpp
+++ b/include/saltatlas/partitioner/voronoi_partitioner.hpp
@@ -78,6 +78,8 @@ class voronoi_partitioner {
     return to_return;
   }
 
+  uint32_t num_partitions() { return m_seeds.size(); }
+
   void fill_seed_hnsw() {
     m_seed_hnsw_ptr = std::make_unique<hnswlib::HierarchicalNSW<dist_t>>(
         &m_space, m_seeds.size(), 16, 200, 3149);


### PR DESCRIPTION
Fixes bug in metric_hyperplane_partitioner concerning identical selectors being chosen and making all theta values to be exactly 0