### PR TITLE
Feature/doxygen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ option(SALTATLAS_INSTALL "Generate the install target"
        ${SALTATLAS_MAIN_PROJECT}
 )
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
+# Option for building Documentation (Doxygen)
+option(SALTATLAS_DOXYGEN "Build API documentation using Doxygen" OFF)
+
 # Only do these if this is the main project, and not if it is included through
 # add_subdirectory
 if (SALTATLAS_MAIN_PROJECT)
@@ -36,6 +41,12 @@ if (SALTATLAS_MAIN_PROJECT)
     # in the main CMakeLists since it calls enable_testing, which must be in the
     # main CMakeLists.
     include(CTest)
+
+    # Doxygen
+    if (SALTATLAS_DOXYGEN)
+        include(saltatlasDoxygen)
+        saltatlasDoxygen()
+    endif()
 endif ()
 
 # Require out-of-source builds

--- a/cmake/saltatlasDoxygen.cmake
+++ b/cmake/saltatlasDoxygen.cmake
@@ -1,0 +1,21 @@
+# Add a target to generate API documentation with Doxygen
+function(saltatlasDoxygen)
+    find_package(Doxygen)
+    if (NOT DOXYGEN_FOUND)
+        message(WARNING "Doxygen not found, will skip Doxygen documentation generation.")
+        return()
+    endif()
+
+    # Set the Doxygen configuration file
+    set(DOXYGEN_GENERATE_HTML YES)
+    set(DOXYGEN_HTML_OUTPUT
+            ${PROJECT_BINARY_DIR}/docs/html)
+    set(DOXYGEN_EXAMPLE_PATH ${PROJECT_SOURCE_DIR}/examples)
+
+    # Add a target 'saltatlas_doxygen'
+    # Run 'make saltatlas_doxygen' to generate the docs
+    doxygen_add_docs(saltatlas_doxygen
+            ${PROJECT_SOURCE_DIR}/include
+            COMMENT "Generate documentation by Doxygen"
+            )
+endfunction()

--- a/cmake/saltatlasDoxygen.cmake
+++ b/cmake/saltatlasDoxygen.cmake
@@ -11,11 +11,16 @@ function(saltatlasDoxygen)
     set(DOXYGEN_HTML_OUTPUT
             ${PROJECT_BINARY_DIR}/docs/html)
     set(DOXYGEN_EXAMPLE_PATH ${PROJECT_SOURCE_DIR}/examples)
+    set(DOXYGEN_EXAMPLE_RECURSIVE YES)
+    set(DOXYGEN_SOURCE_BROWSER YES)
+    set(DOXYGEN_EXCLUDE_PATTERNS ${PROJECT_SOURCE_DIR}/utility/*.py)
 
     # Add a target 'saltatlas_doxygen'
     # Run 'make saltatlas_doxygen' to generate the docs
     doxygen_add_docs(saltatlas_doxygen
             ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/examples
+            ${PROJECT_SOURCE_DIR}/utility
             COMMENT "Generate documentation by Doxygen"
             )
 endfunction()


### PR DESCRIPTION
This PR enables initial Doxygen support.

To generate documentation, 1) pass `SALTATLAS_DOXYGEN=on` option when running CMake; then 2) `make saltatlasDoxygen`.
Open `index.html` in `build/docs/html` using a web browser to see the generated documentation.