### PR TITLE
Incresed required GCC and Boost versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,15 @@ if (EXISTS "${LOC_PATH}")
     )
 endif ()
 
+# Check if the compiler is GCC
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.3.1")
+        message(WARNING "Your GCC version may be too old. Please consider using GCC version 9.3.1 or higher.")
+    endif()
+else()
+    message(WARNING "You are not using GCC. This project has only been tested with GCC. Please consider using GCC version 9.3.1 or higher.")
+endif()
+
 #  Option to use Metall
 option(SALTATLAS_USE_METALL "Use Metall" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,11 +78,11 @@ find_package(OpenMP)
 # supports Boost, we do not need to use the boost-cmake feature.
 set(Boost_NO_BOOST_CMAKE ON)
 
-find_package(Boost 1.64 QUIET)
+find_package(Boost 1.80 QUIET)
 if (NOT Boost_FOUND)
     FetchContent_Declare(
         Boost
-        URL https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2
+        URL https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.bz2
     )
     FetchContent_GetProperties(Boost)
     if (Boost_POPULATED)
@@ -99,7 +99,7 @@ if (NOT Boost_FOUND)
         endif ()
     endif ()
     set(BOOST_ROOT ${boost_SOURCE_DIR})
-    find_package(Boost 1.64)
+    find_package(Boost 1.80)
 else ()
     message(STATUS ${PROJECT_NAME} " found Boost dependency: "
                    ${Boost_INCLUDE_DIR}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ each method will be provided.
 These steps are executed regardless of whether or not Spack is used.
 ``` bash
 # Load an appropriate version of gcc (on LC systems)
-module load gcc/8.3.1
+module load gcc/9.3.1
 git clone https://github.com/LLNL/saltatlas.git
 cd saltatlas
 mkdir build && cd build


### PR DESCRIPTION
- It looks like Boost.JSON fails with gcc/8.3.1. I was able to test with gcc/9.3.1 (which was the next GCC version available on Catalyst). So, this PR has the CMake show a warning if gcc < 9.3.1 is used. It also shows a warning if GCC is not used.

- This PR also changes the minimum Boost version to 1.80. This program may work older versions, but, I propose to change to relatively new version as Boost.JSON is still changing notably.