### PR TITLE
Show warning during CMake if GCC is < 9.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,15 @@ if (EXISTS "${LOC_PATH}")
     )
 endif ()
 
+# Check if the compiler is GCC
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.3.1")
+        message(WARNING "Your GCC version may be too old. Please consider using GCC version 9.3.1 or higher.")
+    endif()
+else()
+    message(WARNING "You are not using GCC. This project has only been tested with GCC. Please consider using GCC version 9.3.1 or higher.")
+endif()
+
 #  Option to use Metall
 option(SALTATLAS_USE_METALL "Use Metall" OFF)
 


### PR DESCRIPTION
This PR makes CMake show a warning if GCC is < 9.3.1 because GCC 8.3.1 with BOOST.JSON >= 1.79 does not work.

This PR intends to help users who run into the build error until we set up the new documentation and CI test.