### PR TITLE
Feature/dhnsw verbose

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,6 +19,7 @@ add_saltatlas_example(dhnsw_example)
 add_saltatlas_example(dhnsw_levenshtein)
 add_saltatlas_example(dhnsw_ascii_levenshtein)
 add_saltatlas_example(dhnsw_big_ann)
+add_saltatlas_example(dhnsw_verbose_levenshtein)
 
 if (SALTATLAS_USE_HDF5)
     add_saltatlas_example(benchmark_hdf5)

--- a/examples/dhnsw_big_ann.cpp
+++ b/examples/dhnsw_big_ann.cpp
@@ -457,7 +457,6 @@ int main(int argc, char** argv) {
           auto store_results_lambda = [](const point_t& query_point,
                                          const std::multimap<dist_t, index_t>&
                                                  nearest_neighbors,
-                                         auto    dist_knn_index,
                                          index_t query_ID) {
             std::pair<index_t, std::vector<std::pair<index_t, dist_t>>> results;
             results.first = query_ID;

--- a/examples/dhnsw_example.cpp
+++ b/examples/dhnsw_example.cpp
@@ -84,9 +84,8 @@ int main(int argc, char **argv) {
 
     // Lambda to execute upon completion of query
     auto report_lambda =
-        [](const point_t                        &query_pt,
-           const std::multimap<dist_t, index_t> &nearest_neighbors,
-           auto                                  dhnsw) {
+        [](const auto &controller, const point_t &query_pt,
+           const std::multimap<dist_t, index_t> &nearest_neighbors) {
           std::cout << "Nearest neighbors for (" << query_pt[0] << ", "
                     << query_pt[1] << "): ";
           for (const auto &[dist, nearest_neighbor_index] : nearest_neighbors) {
@@ -119,10 +118,9 @@ int main(int argc, char **argv) {
 
     // Now query to get features of neighbors
     auto report_features_lambda =
-        [](const point_t &query_pt,
+        [](const auto &controller, const point_t &query_pt,
            const std::multimap<dist_t, std::pair<index_t, point_t>>
-               &nearest_neighbors,
-           auto dhnsw) {
+               &nearest_neighbors) {
           std::cout << "Nearest neighbors for (" << query_pt[0] << ", "
                     << query_pt[1] << "): ";
           for (const auto &[dist, index_point] : nearest_neighbors) {

--- a/examples/dhnsw_levenshtein.cpp
+++ b/examples/dhnsw_levenshtein.cpp
@@ -122,11 +122,10 @@ int main(int argc, char** argv) {
   world.barrier();
 
   auto fuzzy_result_lambda =
-      [](const point_t&                        query_string,
-         const std::multimap<dist_t, index_t>& nearest_neighbors,
-         auto                                  dist_knn_index) {
+      [](const auto& controller, const point_t& query_string,
+         const std::multimap<dist_t, index_t>& nearest_neighbors) {
         for (const auto& result_pair : nearest_neighbors) {
-          dist_knn_index->comm().cout()
+          controller.get_query_engine_ptr()->comm().cout()
               << result_pair.second << " fuzzy dist: " << result_pair.first
               << std::endl;
         }
@@ -140,12 +139,11 @@ int main(int argc, char** argv) {
   world.barrier();
 
   auto fuzzy_result_features_lambda =
-      [](const point_t& query_string,
+      [](const auto& controller, const point_t& query_string,
          const std::multimap<dist_t, std::pair<index_t, point_t>>&
-              nearest_neighbors,
-         auto dist_knn_index) {
+             nearest_neighbors) {
         for (const auto& result_pair : nearest_neighbors) {
-          dist_knn_index->comm().cout()
+          controller.get_query_engine_ptr()->comm().cout()
               << "Point ID: " << result_pair.second.first << ": "
               << result_pair.second.second
               << " fuzzy dist: " << result_pair.first << std::endl;


### PR DESCRIPTION
Adds some features to DHNSW to investigate progression of a completed query. These changes break the previous DHNSW API. Previously, the lambda given to a query operation had the signature 
`my_lambda(query_point, nearest_neighbor_map, pointer_to_dhnsw_index, ...extra args...)`. 
The signature now is 
`my_lambda(*optional* query_controller, query_point, nearest_neighbor_map, ...extra args...)`. 
The optional query_controller argument has access to the dhnsw_index pointer, so no functionality is lost.