### PR TITLE
hotfix/remove_comm_copy_use

### DIFF
--- a/examples/dhnsw_ascii_levenshtein.cpp
+++ b/examples/dhnsw_ascii_levenshtein.cpp
@@ -267,7 +267,7 @@ int main(int argc, char** argv) {
   ygm::container::bag<std::pair<index_t, point_t>> bag_data(world);
   size_t                                           local_counter;
   ascii_lines.for_all(
-      [&bag_data, &local_counter, world](const auto& ascii_line) {
+      [&bag_data, &local_counter, &world](const auto& ascii_line) {
         bag_data.async_insert(std::make_pair(
             (local_counter * world.size()) + world.rank(), ascii_line));
         ++local_counter;

--- a/examples/dhnsw_verbose_levenshtein.cpp
+++ b/examples/dhnsw_verbose_levenshtein.cpp
@@ -265,7 +265,7 @@ int main(int argc, char** argv) {
   ygm::container::bag<std::pair<index_t, point_t>> bag_data(world);
   size_t                                           local_counter;
   ascii_lines.for_all(
-      [&bag_data, &local_counter, world](const auto& ascii_line) {
+      [&bag_data, &local_counter, &world](const auto& ascii_line) {
         bag_data.async_insert(std::make_pair(
             (local_counter * world.size()) + world.rank(), ascii_line));
         ++local_counter;


### PR DESCRIPTION
Updating to be ready for upcoming removal of copy constructor of `ygm::comm` from ygm's develop branch.