### PR TITLE
Removes an unnecessary include from the dnnd_example_commom.hpp that relied on Boost

### DIFF
--- a/examples/dnnd_example_common.hpp
+++ b/examples/dnnd_example_common.hpp
@@ -19,7 +19,6 @@
 #include <ygm/utility.hpp>
 
 #include <saltatlas/dnnd/data_reader.hpp>
-#include <saltatlas/dnnd/dhnsw_index_reader.hpp>
 #include <saltatlas/dnnd/utility.hpp>
 
 /// Returns the name of the given primitive type in string.


### PR DESCRIPTION
@KIwabuchi were you planning on using this included file here? It is causing build issues currently because it relies on the `ygm::io::ndjson_parser` that needs Boost.