### PR TITLE
Updating Boost download location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ find_package(Boost 1.64 QUIET)
 if (NOT Boost_FOUND)
     FetchContent_Declare(
         Boost
-        URL https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2
+        URL https://archives.boost.io/release/1.79.0/source/boost_1_79_0.tar.bz2
     )
     FetchContent_GetProperties(Boost)
     if (Boost_POPULATED)


### PR DESCRIPTION
Changing the download URL for Boost, as seen [here](https://github.com/boostorg/boost/issues/843#issuecomment-2567034014)