### PR TITLE
(DNND) Fast Query (get_neighbors() in KNNG)

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -43,6 +43,9 @@ add_saltatlas_dnnd_example_feature_type(dnnd_bench double)
 
 if (SALTATLAS_USE_METALL)
     add_saltatlas_example(dnnd_advanced)
+    add_saltatlas_example(dnnd_advance_index_build)
+    add_saltatlas_example(dnnd_advance_get_neighbors)
+    add_saltatlas_example(dnnd_advance_query)
 endif ()
 
 add_subdirectory(datasets)

--- a/examples/dnnd_advance_get_neighbors.cpp
+++ b/examples/dnnd_advance_get_neighbors.cpp
@@ -80,8 +80,6 @@ void show_help(cout_type &cout) {
 int main(int argc, char **argv) {
   ygm::comm comm(&argc, &argv);
 
-  metall::logger::set_log_level(metall::logger::level_filter::verbose);
-
   option_t opt;
   bool     help{false};
   if (!parse_options(argc, argv, opt, help)) {
@@ -106,34 +104,38 @@ int main(int argc, char **argv) {
     const auto index_id = g.get_index_ids().front();
     comm.cout0() << "Index ID: " << index_id << std::endl;
 
-    const auto ret =
-        g.get_neighbors(index_id, opt.point_ids.begin(), opt.point_ids.end());
-    for (const auto &item : ret) {
-      const auto &pid       = item.first;
-      const auto &neighbors = item.second;
-      comm.cout0() << "Source point ID: " << pid << std::endl;
-      for (const auto &n : neighbors) {
-        comm.cout0() << "Neighbor ID: " << n.id << " Distance: " << n.distance
-                     << ", " << std::endl;
+    {
+      const auto ret =
+          g.get_neighbors(index_id, opt.point_ids.begin(), opt.point_ids.end());
+      for (const auto &item : ret) {
+        const auto &pid       = item.first;
+        const auto &neighbors = item.second;
+        comm.cout0() << "Source point ID: " << pid << std::endl;
+        for (const auto &n : neighbors) {
+          comm.cout0() << n << std::endl;
+        }
       }
+      comm.cout0() << std::endl;
     }
-    comm.cout0() << std::endl;
 
-    // Demo get_neighbors_with_features
-    const auto ret2 = g.get_neighbors_with_features(
-        index_id, opt.point_ids.begin(), opt.point_ids.end());
-    for (const auto &item : ret2) {
-      const auto &pid       = item.first;
-      const auto &neighbors = item.second.first;
-      const auto &features  = item.second.second;
-      comm.cout0() << "Source point ID: " << pid << std::endl;
-      for (const auto &n : neighbors) {
-        comm.cout0() << "Neighbor ID: " << n.id << " Distance: " << n.distance
-                     << ", " << std::endl;
+    {
+      std::vector<id_t> ids;
+      if (comm.rank() == 0) {
+        ids.push_back(0);
+        ids.push_back(1);
       }
-      comm.cout0() << "Features: ";
-      for (const auto &f : features) {
-        comm.cout0() << saltatlas::to_string(f) << " ";
+      const auto neighbors_and_features =
+          g.get_neighbors_with_features(index_id, ids.begin(), ids.end());
+      for (const auto &[id, item] : neighbors_and_features) {
+        comm.cout0() << "Source point ID: " << id << std::endl;
+        const auto &neighbors = item.first;
+        const auto &features  = item.second;
+        for (int i = 0; i < neighbors.size(); ++i) {
+          comm.cout0() << neighbors[i]
+                       << ", feature = " << saltatlas::to_string(features[i])
+                       << std::endl;
+        }
+        comm.cout0() << std::endl;
       }
     }
 

--- a/examples/dnnd_advance_get_neighbors.cpp
+++ b/examples/dnnd_advance_get_neighbors.cpp
@@ -1,0 +1,144 @@
+// Copyright 2024 Lawrence Livermore National Security, LLC and other
+// saltatlas Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+/// \brief A simple example of building k-NN index (KNN graph) in Metall
+/// datastore. Usage:
+///     cd build
+///     mpirun -n 2 ./example/dnnd_advanced_index_build -p /path/to/points -f l2
+
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <ygm/comm.hpp>
+
+#include <saltatlas/dnnd/dnnd_advanced.hpp>
+
+// Point ID type
+using id_t   = uint32_t;
+using dist_t = double;
+
+// Point Type
+using point_type = saltatlas::pm_feature_vector<float>;
+
+struct option_t {
+  std::filesystem::path datastore_path;
+  std::vector<id_t>     point_ids;
+};
+
+bool parse_options(int argc, char **argv, option_t &opt, bool &help) {
+  opt.datastore_path.clear();
+  help = false;
+
+  int n;
+  while ((n = ::getopt(argc, argv, "d:p:h")) != -1) {
+    switch (n) {
+      case 'd':
+        opt.datastore_path = optarg;
+        break;
+
+      case 'p':  // comma separated list of point ids
+      {
+        std::string        point_ids_str = optarg;
+        std::istringstream ss(point_ids_str);
+        std::string        token;
+        while (std::getline(ss, token, ',')) {
+          opt.point_ids.push_back(std::stoi(token));
+        }
+        break;
+      }
+
+      case 'h':
+        help = true;
+        return true;
+
+      default:
+        return false;
+    }
+  }
+
+  if (opt.datastore_path.empty()) {
+    return false;
+  }
+
+  return true;
+}
+
+template <typename cout_type>
+void show_help(cout_type &cout) {
+  cout
+      << "Usage: ./dnnd_advance_show_neighbors [options]\n"
+         "Options:\n"
+         "  -d <string>       The Metall datastore path\n"
+         "  -p <string>       Comma separated list of point IDs (e.g., 0,2,5)\n"
+         "  -h                Show this help message\n";
+}
+
+int main(int argc, char **argv) {
+  ygm::comm comm(&argc, &argv);
+
+  metall::logger::set_log_level(metall::logger::level_filter::verbose);
+
+  option_t opt;
+  bool     help{false};
+  if (!parse_options(argc, argv, opt, help)) {
+    comm.cerr0() << "Invalid option" << std::endl;
+    show_help(comm.cerr0());
+    return EXIT_FAILURE;
+  }
+  if (help) {
+    show_help(comm.cout0());
+    return 0;
+  }
+  if (!comm.rank0()) {
+    // Only rank 0 request neighbors in this demo
+    opt.point_ids.clear();
+  }
+
+  {
+    saltatlas::dnnd<id_t, point_type, dist_t> g(saltatlas::open_read_only,
+                                                opt.datastore_path, comm);
+
+    // Use the first index for demo
+    const auto index_id = g.get_index_ids().front();
+    comm.cout0() << "Index ID: " << index_id << std::endl;
+
+    const auto ret =
+        g.get_neighbors(index_id, opt.point_ids.begin(), opt.point_ids.end());
+    for (const auto &item : ret) {
+      const auto &pid       = item.first;
+      const auto &neighbors = item.second;
+      comm.cout0() << "Source point ID: " << pid << std::endl;
+      for (const auto &n : neighbors) {
+        comm.cout0() << "Neighbor ID: " << n.id << " Distance: " << n.distance
+                     << ", " << std::endl;
+      }
+    }
+    comm.cout0() << std::endl;
+
+    // Demo get_neighbors_with_features
+    const auto ret2 = g.get_neighbors_with_features(
+        index_id, opt.point_ids.begin(), opt.point_ids.end());
+    for (const auto &item : ret2) {
+      const auto &pid       = item.first;
+      const auto &neighbors = item.second.first;
+      const auto &features  = item.second.second;
+      comm.cout0() << "Source point ID: " << pid << std::endl;
+      for (const auto &n : neighbors) {
+        comm.cout0() << "Neighbor ID: " << n.id << " Distance: " << n.distance
+                     << ", " << std::endl;
+      }
+      comm.cout0() << "Features: ";
+      for (const auto &f : features) {
+        comm.cout0() << saltatlas::to_string(f) << " ";
+      }
+    }
+
+    comm.cf_barrier();
+  }
+
+  return 0;
+}

--- a/examples/dnnd_advance_index_build.cpp
+++ b/examples/dnnd_advance_index_build.cpp
@@ -1,0 +1,135 @@
+// Copyright 2024 Lawrence Livermore National Security, LLC and other
+// saltatlas Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+/// \brief A simple example of building k-NN index (KNN graph) in Metall
+/// datastore. Usage:
+///     cd build
+///     mpirun -n 2 ./example/dnnd_advanced_index_build -p /path/to/points -f l2
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include <filesystem>
+
+#include <ygm/comm.hpp>
+
+#include <saltatlas/dnnd/dnnd_advanced.hpp>
+
+// Point ID type
+using id_t   = uint32_t;
+using dist_t = double;
+
+// Point Type
+using point_type = saltatlas::pm_feature_vector<float>;
+
+struct option_t {
+  int                                index_k;
+  std::string                        distance_name;
+  std::vector<std::filesystem::path> point_file_names;
+  std::string                        point_file_format;
+  std::filesystem::path              datastore_path;
+};
+
+bool parse_options(int argc, char **argv, option_t &opt, bool &help) {
+  opt.index_k = 0;
+  opt.distance_name.clear();
+  opt.point_file_names.clear();
+  opt.point_file_format.clear();
+  opt.datastore_path.clear();
+  help = false;
+
+  int n;
+  while ((n = ::getopt(argc, argv, "k:f:p:d:h")) != -1) {
+    switch (n) {
+      case 'k':
+        opt.index_k = std::stoi(optarg);
+        break;
+
+      case 'f':
+        opt.distance_name = optarg;
+        break;
+
+      case 'p':
+        opt.point_file_format = optarg;
+        break;
+
+      case 'd':
+        opt.datastore_path = optarg;
+        break;
+
+      case 'h':
+        help = true;
+        return true;
+
+      default:
+        return false;
+    }
+  }
+
+  for (int index = optind; index < argc; index++) {
+    opt.point_file_names.emplace_back(argv[index]);
+  }
+
+  if (opt.index_k <= 0) {
+    return false;
+  }
+
+  if (opt.distance_name.empty() || opt.point_file_format.empty() ||
+      opt.point_file_names.empty() || opt.datastore_path.empty()) {
+    return false;
+  }
+
+  return true;
+}
+
+template <typename cout_type>
+void show_help(cout_type &cout) {
+  cout << "Usage: ./dnnd_advanced_index_build [options] point_files...\n"
+          "Options:\n"
+          "  -k <int>          The number of neighbors to build the index\n"
+          "  -f <string>       The distance function name\n"
+          "  -p <string>       The point file format\n"
+          "  -d <string>       The Metall datastore path\n"
+          "  -h                Show this help message\n";
+}
+
+int main(int argc, char **argv) {
+  ygm::comm comm(&argc, &argv);
+
+  option_t opt;
+  bool     help{false};
+  if (!parse_options(argc, argv, opt, help)) {
+    comm.cerr0() << "Invalid option" << std::endl;
+    show_help(comm.cerr0());
+    return EXIT_FAILURE;
+  }
+  if (help) {
+    show_help(comm.cout0());
+    return 0;
+  }
+
+  std::error_code ec;
+  std::filesystem::remove_all(opt.datastore_path, ec);
+  comm.cf_barrier();
+  {
+    saltatlas::dnnd<id_t, point_type, dist_t> g(saltatlas::create_only,
+                                                opt.datastore_path, comm);
+
+    g.load_points(opt.point_file_names.begin(), opt.point_file_names.end(),
+                  opt.point_file_format);
+
+    const auto distance_func =
+        saltatlas::distance::distance_function<point_type, dist_t>(
+            opt.distance_name);
+
+    comm.cout0() << "Building index" << std::endl;
+    const auto index_id = g.build(distance_func, opt.index_k);
+
+    comm.cout0() << "Optimizing index" << std::endl;
+    g.optimize(index_id, distance_func);
+  }
+
+  return 0;
+}

--- a/examples/dnnd_advance_query.cpp
+++ b/examples/dnnd_advance_query.cpp
@@ -26,38 +26,31 @@ using point_type = saltatlas::pm_feature_vector<float>;
 
 struct option_t {
   std::filesystem::path datastore_path;
-  std::vector<id_t>     point_ids;
   std::string           distance_name;
+  std::filesystem::path query_file_path;
   int                   query_n;  // #of neighbor points to search
 };
 
 bool parse_options(int argc, char **argv, option_t &opt, bool &help) {
   opt.datastore_path.clear();
-  opt.point_ids.clear();
   opt.distance_name.clear();
+  opt.query_file_path.clear();
   opt.query_n = 0;
   help        = false;
 
   int n;
-  while ((n = ::getopt(argc, argv, "d:p:f:n:h")) != -1) {
+  while ((n = ::getopt(argc, argv, "d:f:q:n:h")) != -1) {
     switch (n) {
       case 'd':
         opt.datastore_path = optarg;
         break;
 
-      case 'p':  // comma separated list of point ids
-      {
-        std::string        point_ids_str = optarg;
-        std::istringstream ss(point_ids_str);
-        std::string        token;
-        while (std::getline(ss, token, ',')) {
-          opt.point_ids.push_back(std::stoi(token));
-        }
-        break;
-      }
-
       case 'f':
         opt.distance_name = optarg;
+        break;
+
+      case 'q':
+        opt.query_file_path = optarg;
         break;
 
       case 'n':
@@ -74,7 +67,7 @@ bool parse_options(int argc, char **argv, option_t &opt, bool &help) {
   }
 
   if (opt.datastore_path.empty() || opt.distance_name.empty() ||
-      opt.point_ids.empty()) {
+      opt.query_file_path.empty() || opt.query_n <= 0) {
     return false;
   }
 
@@ -108,27 +101,30 @@ int main(int argc, char **argv) {
     return 0;
   }
 
+  std::vector<point_type> queries;
+  saltatlas::read_query(opt.query_file_path, queries, comm);
+
+  const auto distance_func =
+      saltatlas::distance::distance_function<point_type, dist_t>(
+          opt.distance_name);
   {
     saltatlas::dnnd<id_t, point_type, dist_t> g(saltatlas::open_read_only,
                                                 opt.datastore_path, comm);
-    const auto                                distance_func =
-        saltatlas::distance::distance_function<point_type, dist_t>(
-            opt.distance_name);
-    const auto index_ids = g.get_index_ids();
-    for (const auto index_id : index_ids) {
-      comm.cout0() << "Run queries on index: " << index_id << std::endl;
-      const auto ret = g.query(index_id, distance_func, opt.point_ids.begin(),
-                               opt.point_ids.end(), opt.query_n);
-      for (int qid = 0; qid < ret.size(); ++qid) {
-        const auto &pid       = opt.point_ids[qid];
-        const auto &neighbors = ret[qid];
-        comm.cout0() << "Query source point ID: " << pid << std::endl;
-        for (const auto &n : neighbors) {
-          comm.cout0() << "Neighbor ID: " << n.id << " Distance: " << n.distance
-                       << ", " << std::endl;
+    const auto                                index_ids = g.get_index_ids();
+
+    // Run queries
+    {
+      for (const auto index_id : index_ids) {
+        comm.cout0() << "Run queries on index: " << index_id << std::endl;
+        const auto ret = g.query(index_id, distance_func, queries.begin(),
+                                 queries.end(), opt.query_n);
+        for (std::size_t i = 0; i < ret.size(); ++i) {
+          comm.cout0() << "Query " << i << ":\n";
+          for (const auto &neighbor : ret[i]) {
+            comm.cout0() << "  " << neighbor << std::endl;
+          }
         }
       }
-      comm.cout0() << "\n" << std::endl;
     }
     comm.cf_barrier();
   }

--- a/examples/dnnd_advance_query.cpp
+++ b/examples/dnnd_advance_query.cpp
@@ -1,0 +1,137 @@
+// Copyright 2024 Lawrence Livermore National Security, LLC and other
+// saltatlas Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: MIT
+
+/// \brief A simple example of building k-NN index (KNN graph) in Metall
+/// datastore. Usage:
+///     cd build
+///     mpirun -n 2 ./example/dnnd_advanced_index_build -p /path/to/points -f l2
+
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <ygm/comm.hpp>
+
+#include <saltatlas/dnnd/dnnd_advanced.hpp>
+
+// Point ID type
+using id_t   = uint32_t;
+using dist_t = double;
+
+// Point Type
+using point_type = saltatlas::pm_feature_vector<float>;
+
+struct option_t {
+  std::filesystem::path datastore_path;
+  std::vector<id_t>     point_ids;
+  std::string           distance_name;
+  int                   query_n;  // #of neighbor points to search
+};
+
+bool parse_options(int argc, char **argv, option_t &opt, bool &help) {
+  opt.datastore_path.clear();
+  opt.point_ids.clear();
+  opt.distance_name.clear();
+  opt.query_n = 0;
+  help        = false;
+
+  int n;
+  while ((n = ::getopt(argc, argv, "d:p:f:n:h")) != -1) {
+    switch (n) {
+      case 'd':
+        opt.datastore_path = optarg;
+        break;
+
+      case 'p':  // comma separated list of point ids
+      {
+        std::string        point_ids_str = optarg;
+        std::istringstream ss(point_ids_str);
+        std::string        token;
+        while (std::getline(ss, token, ',')) {
+          opt.point_ids.push_back(std::stoi(token));
+        }
+        break;
+      }
+
+      case 'f':
+        opt.distance_name = optarg;
+        break;
+
+      case 'n':
+        opt.query_n = std::stoi(optarg);
+        break;
+
+      case 'h':
+        help = true;
+        return true;
+
+      default:
+        return false;
+    }
+  }
+
+  if (opt.datastore_path.empty() || opt.distance_name.empty() ||
+      opt.point_ids.empty()) {
+    return false;
+  }
+
+  return true;
+}
+
+template <typename cout_type>
+void show_help(cout_type &cout) {
+  cout << "Usage: ./dnnd_advance_show_neighbors [options]\n"
+          "Options:\n"
+          "  -d <string>       The Metall datastore path\n"
+          "  -f <string>       The distance function\n"
+          "  -p <string>       Comma separated list of query source point IDs "
+          "(e.g., 0,2,5)\n"
+          "  -n <int>          The number of neighbor points to search\n"
+          "  -h                Show this help message\n";
+}
+
+int main(int argc, char **argv) {
+  ygm::comm comm(&argc, &argv);
+
+  option_t opt;
+  bool     help{false};
+  if (!parse_options(argc, argv, opt, help)) {
+    comm.cerr0() << "Invalid option" << std::endl;
+    show_help(comm.cerr0());
+    return EXIT_FAILURE;
+  }
+  if (help) {
+    show_help(comm.cout0());
+    return 0;
+  }
+
+  {
+    saltatlas::dnnd<id_t, point_type, dist_t> g(saltatlas::open_read_only,
+                                                opt.datastore_path, comm);
+    const auto                                distance_func =
+        saltatlas::distance::distance_function<point_type, dist_t>(
+            opt.distance_name);
+    const auto index_ids = g.get_index_ids();
+    for (const auto index_id : index_ids) {
+      comm.cout0() << "Run queries on index: " << index_id << std::endl;
+      const auto ret = g.query(index_id, distance_func, opt.point_ids.begin(),
+                               opt.point_ids.end(), opt.query_n);
+      for (int qid = 0; qid < ret.size(); ++qid) {
+        const auto &pid       = opt.point_ids[qid];
+        const auto &neighbors = ret[qid];
+        comm.cout0() << "Query source point ID: " << pid << std::endl;
+        for (const auto &n : neighbors) {
+          comm.cout0() << "Neighbor ID: " << n.id << " Distance: " << n.distance
+                       << ", " << std::endl;
+        }
+      }
+      comm.cout0() << "\n" << std::endl;
+    }
+    comm.cf_barrier();
+  }
+
+  return 0;
+}

--- a/examples/dnnd_advance_query.cpp
+++ b/examples/dnnd_advance_query.cpp
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
     // Run queries
     {
       for (const auto index_id : index_ids) {
-        comm.cout0() << "Run queries on index: " << index_id << std::endl;
+        comm.cout0() << "Run queries on index " << index_id << std::endl;
         const auto ret = g.query(index_id, distance_func, queries.begin(),
                                  queries.end(), opt.query_n);
         for (std::size_t i = 0; i < ret.size(); ++i) {
@@ -127,6 +127,26 @@ int main(int argc, char **argv) {
       }
     }
     comm.cf_barrier();
+
+    // Run queries and receive neighbor features
+    {
+      for (const auto index_id : index_ids) {
+        comm.cout0() << "\nRun queries on index " << index_id << std::endl;
+        const auto ret =
+            g.query_with_features(index_id, distance_func, queries.begin(),
+                                  queries.end(), opt.query_n);
+        const auto &neighbors = ret.first;
+        const auto &features  = ret.second;
+        for (std::size_t qi = 0; qi < queries.size(); ++qi) {
+          comm.cout0() << "Query " << qi << ":\n";
+          for (int ni = 0; ni < neighbors[qi].size(); ++ni) {
+            comm.cout0() << neighbors[qi][ni] << ", feature = "
+                         << saltatlas::to_string(features[qi][ni]) << std::endl;
+          }
+          comm.cout0() << std::endl;
+        }
+      }
+    }
   }
 
   return 0;

--- a/examples/dnnd_advanced.cpp
+++ b/examples/dnnd_advanced.cpp
@@ -20,6 +20,9 @@ using id_t   = uint32_t;
 using dist_t = double;
 
 // Point Type
+// If one uses Metall's STL-allocator to allocate container in Metall's memory
+// space, metall::manager::fallback_allocator must be used because DNND
+// allocates temporal point instances.
 using point_type = saltatlas::pm_feature_vector<float>;
 
 // Custom distance function
@@ -45,7 +48,7 @@ int main(int argc, char** argv) {
     g.load_points(paths.begin(), paths.end(), "wsv");
 
     // ----- NNG build and NN search APIs ----- //
-    int        k  = 4;
+    int        k        = 4;
     const auto index_id = g.build(saltatlas::distance::id::l2, k);
 
     bool make_graph_undirected = true;
@@ -57,8 +60,8 @@ int main(int argc, char** argv) {
       queries.push_back(point_type{61.58, 29.68, 20.43, 99.22, 21.81});
     }
     int        num_to_search = 4;
-    const auto results       = g.query(index_id, saltatlas::distance::id::l2, queries.begin(),
-                                       queries.end(), num_to_search);
+    const auto results       = g.query(index_id, saltatlas::distance::id::l2,
+                                       queries.begin(), queries.end(), num_to_search);
 
     if (comm.rank() == 0) {
       std::cout << "Neighbours (id, distance):";

--- a/examples/dnnd_advanced.cpp
+++ b/examples/dnnd_advanced.cpp
@@ -46,10 +46,10 @@ int main(int argc, char** argv) {
 
     // ----- NNG build and NN search APIs ----- //
     int        k  = 4;
-    const auto id = g.build(saltatlas::distance::id::l2, k);
+    const auto index_id = g.build(saltatlas::distance::id::l2, k);
 
     bool make_graph_undirected = true;
-    g.optimize(id, saltatlas::distance::id::l2, make_graph_undirected);
+    g.optimize(index_id, saltatlas::distance::id::l2, make_graph_undirected);
 
     // Run queries
     std::vector<point_type> queries;
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
       queries.push_back(point_type{61.58, 29.68, 20.43, 99.22, 21.81});
     }
     int        num_to_search = 4;
-    const auto results       = g.query(id, saltatlas::distance::id::l2, queries.begin(),
+    const auto results       = g.query(index_id, saltatlas::distance::id::l2, queries.begin(),
                                        queries.end(), num_to_search);
 
     if (comm.rank() == 0) {
@@ -80,8 +80,8 @@ int main(int argc, char** argv) {
     std::vector<std::filesystem::path>        paths{
         "../examples/datasets/point_5-4.txt"};
     g.load_points(paths.begin(), paths.end(), "wsv");
-    const auto id = g.build(custom_distance, 2);
-    comm.cout0() << "Created KNNG " << id << std::endl;
+    const auto index_id = g.build(custom_distance, 2);
+    comm.cout0() << "Created KNNG " << index_id << std::endl;
   }
 
   {
@@ -90,8 +90,8 @@ int main(int argc, char** argv) {
     g.update(0, custom_distance, 4);
     comm.cout0() << "Updated KNNG " << 0 << std::endl;
 
-    auto id = g.build(custom_distance, 4);
-    comm.cout0() << "Created KNNG " << id << std::endl;
+    auto index_id = g.build(custom_distance, 4);
+    comm.cout0() << "Created KNNG " << index_id << std::endl;
   }
 
   {

--- a/examples/dnnd_simple.cpp
+++ b/examples/dnnd_simple.cpp
@@ -139,11 +139,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  // Dump a KNNG to files
-  g.dump_graph("./knng");
-  comm.cout0() << "\nKNNG dumped to ./knng" << std::endl;
-
-  comm.cout0() << "\nGet the neighbors" << std::endl;
+  comm.cout0() << "\nGet neighbors" << std::endl;
   {
     std::vector<id_t> ids;
     if (comm.rank() == 0) {
@@ -152,13 +148,38 @@ int main(int argc, char** argv) {
     }
     const auto neighbors = g.get_neighbors(ids.begin(), ids.end());
     for (const auto& [id, nbs] : neighbors) {
-      comm.cout0() << "Point ID " << id;
+      comm.cout0() << "Source point ID: " << id;
       for (const auto& nb : nbs) {
         comm.cout0() << " -> " << nb;
       }
       comm.cout0() << std::endl;
     }
   }
+
+  comm.cout0() << "\nGet neighbors with features" << std::endl;
+  {
+    std::vector<id_t> ids;
+    if (comm.rank() == 0) {
+      ids.push_back(0);
+      ids.push_back(1);
+    }
+    const auto neighbors_and_features =
+        g.get_neighbors_with_features(ids.begin(), ids.end());
+    for (const auto& [id, item] : neighbors_and_features) {
+      comm.cout0() << "Source point ID: " << id << std::endl;
+      const auto& neighbors = item.first;
+      const auto& features = item.second;
+      for (int i = 0; i < neighbors.size(); ++i) {
+        comm.cout0() << neighbors[i] << ", feature = "
+                     << saltatlas::to_string(features[i]) << std::endl;
+      }
+      comm.cout0() << std::endl;
+    }
+  }
+
+  // Dump a KNNG to files
+  g.dump_graph("./knng");
+  comm.cout0() << "\nKNNG dumped to ./knng" << std::endl;
 
   return 0;
 }

--- a/examples/dnnd_simple.cpp
+++ b/examples/dnnd_simple.cpp
@@ -75,7 +75,9 @@ int main(int argc, char** argv) {
     }
 
     // Get nearest neighbours with features
-    comm.cout0()<< "\nNearest neighbor query result with features\n(show only the nearest point of the query from rank 0)" << std::endl;
+    comm.cout0() << "\nNearest neighbor query result with features\n(show only "
+                    "the nearest point of the query from rank 0)"
+                 << std::endl;
     {
       int        num_to_search = 4;
       const auto results =
@@ -85,7 +87,7 @@ int main(int argc, char** argv) {
         auto& neighbours = results.first;
         auto& features   = results.second;
         std::cout << "Point ID " << neighbours[0][0].id << ", distance "
-                     << neighbours[0][0].distance << ", feature {";
+                  << neighbours[0][0].distance << ", feature {";
         for (const auto& v : features[0][0]) {
           std::cout << v << " ";
         }
@@ -118,8 +120,9 @@ int main(int argc, char** argv) {
     }
   }
 
-  comm.cout0() << "\nGet points including the ones that are stored in other ranks"
-               << std::endl;
+  comm.cout0()
+      << "\nGet points including the ones that are stored in other ranks"
+      << std::endl;
   {
     id_t ids[]  = {0, 1};
     auto points = g.get_points(ids, ids + 2);
@@ -135,6 +138,19 @@ int main(int argc, char** argv) {
   // Dump a KNNG to files
   g.dump_graph("./knng");
   comm.cout0() << "KNNG dumped to ./knng" << std::endl;
+
+  comm.cout0() << "\nGet the neighbors" << std::endl;
+  {
+    id_t ids[]     = {0, 1};
+    const auto neighbors = g.get_neighbors(ids, ids + 2);
+    for (const auto& [id, nbs] : neighbors) {
+      comm.cout0() << "Point ID " << id;
+      for (const auto& nb : nbs) {
+        comm.cout0() << " -> " << nb;
+      }
+      comm.cout0() << std::endl;
+    }
+  }
 
   return 0;
 }

--- a/examples/dnnd_simple.cpp
+++ b/examples/dnnd_simple.cpp
@@ -124,8 +124,12 @@ int main(int argc, char** argv) {
       << "\nGet points including the ones that are stored in other ranks"
       << std::endl;
   {
-    id_t ids[]  = {0, 1};
-    auto points = g.get_points(ids, ids + 2);
+    std::vector<id_t> ids;
+    if (comm.rank() == 0) {
+      ids.push_back(0);
+      ids.push_back(1);
+    }
+    auto points = g.get_points(ids.begin(), ids.end());
     for (const auto& [id, point] : points) {
       comm.cout0() << "Point ID " << id << " : ";
       for (const auto& v : point) {
@@ -137,12 +141,16 @@ int main(int argc, char** argv) {
 
   // Dump a KNNG to files
   g.dump_graph("./knng");
-  comm.cout0() << "KNNG dumped to ./knng" << std::endl;
+  comm.cout0() << "\nKNNG dumped to ./knng" << std::endl;
 
   comm.cout0() << "\nGet the neighbors" << std::endl;
   {
-    id_t ids[]     = {0, 1};
-    const auto neighbors = g.get_neighbors(ids, ids + 2);
+    std::vector<id_t> ids;
+    if (comm.rank() == 0) {
+      ids.push_back(0);
+      ids.push_back(1);
+    }
+    const auto neighbors = g.get_neighbors(ids.begin(), ids.end());
     for (const auto& [id, nbs] : neighbors) {
       comm.cout0() << "Point ID " << id;
       for (const auto& nb : nbs) {

--- a/include/saltatlas/dnnd/detail/nn_index.hpp
+++ b/include/saltatlas/dnnd/detail/nn_index.hpp
@@ -56,15 +56,17 @@ class nn_index {
   using neighbor_type  = detail::neighbor<id_type, distance_type>;
   using allocator_type = Allocator;
 
- private:
   using neighbor_list_type =
       container::vector<neighbor_type,
                         other_allocator<allocator_type, neighbor_type>>;
+
+ private:
   using point_table_type = container::unordered_map<
       id_type, neighbor_list_type, std::hash<id_type>, std::equal_to<>,
       other_scoped_allocator<allocator_type,
                              std::pair<const id_type, neighbor_list_type>>>;
 
+ public:
   using point_iterator          = typename point_table_type::iterator;
   using const_point_iterator    = typename point_table_type::const_iterator;
   using neighbor_iterator       = typename neighbor_list_type::iterator;
@@ -98,8 +100,8 @@ class nn_index {
 
   void sort_and_remove_duplicate_neighbors(const id_type &source) {
     sort_neighbors(source);
-    auto& nns_list = m_index[source];
-    auto last = std::unique(nns_list.begin(), nns_list.end());
+    auto &nns_list = m_index[source];
+    auto  last     = std::unique(nns_list.begin(), nns_list.end());
     nns_list.erase(last, nns_list.end());
     nns_list.shrink_to_fit();
   }
@@ -113,26 +115,28 @@ class nn_index {
     m_index[source].shrink_to_fit();
   }
 
-  auto points_begin() { return m_index.begin(); }
+  point_iterator points_begin() { return m_index.begin(); }
 
-  auto points_end() { return m_index.end(); }
+  point_iterator points_end() { return m_index.end(); }
 
-  auto points_begin() const { return m_index.begin(); }
+  const_point_iterator points_begin() const { return m_index.begin(); }
 
-  auto points_end() const { return m_index.end(); }
+  const_point_iterator points_end() const { return m_index.end(); }
 
-  auto neighbors_begin(const id_type &source) {
+  neighbor_iterator neighbors_begin(const id_type &source) {
     return m_index[source].begin();
   }
 
-  auto neighbors_end(const id_type &source) { return m_index[source].end(); }
+  neighbor_iterator neighbors_end(const id_type &source) {
+    return m_index[source].end();
+  }
 
-  auto neighbors_begin(const id_type &source) const {
+  const_neighbor_iterator neighbors_begin(const id_type &source) const {
     assert(m_index.count(source) > 0);
     return m_index.at(source).begin();
   }
 
-  auto neighbors_end(const id_type &source) const {
+  const_neighbor_iterator neighbors_end(const id_type &source) const {
     assert(m_index.count(source) > 0);
     return m_index.at(source).end();
   }

--- a/include/saltatlas/dnnd/dnnd_advanced.hpp
+++ b/include/saltatlas/dnnd/dnnd_advanced.hpp
@@ -472,18 +472,6 @@ class dnnd {
     optimizer.run();
   }
 
-  template <typename query_iterator>
-  neighbor_store_type query(const std::size_t   index_id,
-                            const distance::id& distance_func_id,
-                            query_iterator      queries_begin,
-                            query_iterator queries_end, const int k,
-                            const double epsilon = 0.1) {
-    return query(index_id,
-                 distance::distance_function<point_type, distance_type>(
-                     distance_func_id),
-                 queries_begin, queries_end, k, epsilon);
-  }
-
   /// \brief Query nearest neighbors of given points.
   /// This function assumes that the query points are already distributed.
   /// Query results are returned to the MPI rank that submitted the queries.
@@ -522,17 +510,43 @@ class dnnd {
     return query_result;
   }
 
-  template <typename index_id_iterator, typename query_iterator>
-  neighbor_store_type query(index_id_iterator   index_ids_begin,
-                            index_id_iterator   index_ids_end,
+  template <typename query_iterator>
+  std::pair<neighbor_store_type, std::vector<std::vector<point_type>>>
+  query_with_features(const std::size_t      index_id,
+                      distance_function_type distance_function,
+                      query_iterator queries_begin, query_iterator queries_end,
+                      const int k, const double epsilon = 0.1) {
+    auto query_result = query(index_id, distance_function, queries_begin,
+                              queries_end, k, epsilon);
+    return std::make_pair(query_result,
+                          priv_get_features_for_query_results(query_result));
+  }
+
+  /// \brief The same as query() but with distance function ID.
+  template <typename query_iterator>
+  neighbor_store_type query(const std::size_t   index_id,
                             const distance::id& distance_func_id,
                             query_iterator      queries_begin,
                             query_iterator queries_end, const int k,
                             const double epsilon = 0.1) {
-    return query(index_ids_begin, index_ids_end,
+    return query(index_id,
                  distance::distance_function<point_type, distance_type>(
                      distance_func_id),
                  queries_begin, queries_end, k, epsilon);
+  }
+
+  /// \brief The same as query_with_features() but with distance function ID.
+  template <typename query_iterator>
+  std::pair<neighbor_store_type, std::vector<std::vector<point_type>>>
+  query_with_features(const std::size_t   index_id,
+                      const distance::id& distance_func_id,
+                      query_iterator queries_begin, query_iterator queries_end,
+                      const int k, const double epsilon = 0.1) {
+    return query_with_features(
+        index_id,
+        distance::distance_function<point_type, distance_type>(
+            distance_func_id),
+        queries_begin, queries_end, k, epsilon);
   }
 
   /// \brief Query nearest neighbors of given points.
@@ -569,7 +583,50 @@ class dnnd {
     return query_result;
   }
 
-  /// TODO: implement query_with_features()
+  /// \brief The same as query() but runs on multiple indices and returns neighbor
+  /// features.
+  template <typename index_id_iterator, typename query_iterator>
+  std::pair<neighbor_store_type, std::vector<std::vector<point_type>>>
+  query_with_features(index_id_iterator      index_ids_begin,
+                      index_id_iterator      index_ids_end,
+                      distance_function_type distance_function,
+                      query_iterator queries_begin, query_iterator queries_end,
+                      const int k, const double epsilon = 0.1) {
+    auto query_result = query(index_ids_begin, index_ids_end, distance_function,
+                              queries_begin, queries_end, k, epsilon);
+    return std::make_pair(query_result,
+                          priv_get_features_for_query_results(query_result));
+  }
+
+  /// \brief The same as query() but with distance function ID and on multiple
+  /// indices.
+  template <typename index_id_iterator, typename query_iterator>
+  neighbor_store_type query(index_id_iterator   index_ids_begin,
+                            index_id_iterator   index_ids_end,
+                            const distance::id& distance_func_id,
+                            query_iterator      queries_begin,
+                            query_iterator queries_end, const int k,
+                            const double epsilon = 0.1) {
+    return query(index_ids_begin, index_ids_end,
+                 distance::distance_function<point_type, distance_type>(
+                     distance_func_id),
+                 queries_begin, queries_end, k, epsilon);
+  }
+
+  /// \brief The same as query() but with distance function ID and on multiple
+  /// indices. Returns neighbor features also.
+  template <typename index_id_iterator, typename query_iterator>
+  std::pair<neighbor_store_type, std::vector<std::vector<point_type>>>
+  query_with_features(index_id_iterator   index_ids_begin,
+                      index_id_iterator   index_ids_end,
+                      const distance::id& distance_func_id,
+                      query_iterator queries_begin, query_iterator queries_end,
+                      const int k, const double epsilon = 0.1) {
+    return query(index_ids_begin, index_ids_end,
+                 distance::distance_function<point_type, distance_type>(
+                     distance_func_id),
+                 queries_begin, queries_end, k, epsilon);
+  }
 
   /// \brief Dump the k-NN index to distributed files.
   /// \param out_file_prefix File path prefix.
@@ -642,7 +699,10 @@ class dnnd {
       comm->async(
           source_rank,
           [](auto, const auto& id, auto point) {
-            return_points_store.emplace(id, std::move(point));
+            // Avoid duplicate insertion to get better performance.
+            if (!return_points_store.contains(id)) {
+              return_points_store.emplace(id, std::move(point));
+            }
           },
           id, std::move(point));
     };
@@ -776,10 +836,12 @@ class dnnd {
         id_type, std::pair<std::vector<neighbor_type>, std::vector<point_type>>>
         result;
     for (auto& [id, neighbors] : neighbors_table) {
-      std::vector<point_type> neighbor_features;
-      for (const auto& neighbor : neighbors) {
-        neighbor_features.push_back(
-            std::move(neighbor_features_table.at(neighbor.id)));
+      // Construct neighbor feature vector
+      // The line below makes the fallback_allocator in the point_type not to
+      // get stateful allocator.
+      std::vector<point_type> neighbor_features(neighbors.size());
+      for (size_t i = 0; i < neighbors.size(); ++i) {
+        neighbor_features[i] = neighbor_features_table.at(neighbors[i].id);
       }
 
       result[id] =
@@ -807,6 +869,30 @@ class dnnd {
       return dndetail::murmurhash::hash<5981>{}(id) % size;
     };
   };
+
+  std::vector<std::vector<point_type>> priv_get_features_for_query_results(
+      const neighbor_store_type& query_results) {
+    std::set<id_type> neighbor_ids;
+    for (const auto& neighbors : query_results) {
+      for (const auto& neighbor : neighbors) {
+        neighbor_ids.insert(neighbor.id);
+      }
+    }
+    auto neighbor_features_table =
+        get_points(neighbor_ids.begin(), neighbor_ids.end());
+
+    std::vector<std::vector<point_type>> neighbor_features_to_return;
+    for (std::size_t i = 0; i < query_results.size(); ++i) {
+      std::vector<point_type> neighbor_features(query_results[i].size());
+      for (std::size_t j = 0; j < query_results[i].size(); ++j) {
+        neighbor_features[j] =
+            neighbor_features_table.at(query_results[i][j].id);
+      }
+      neighbor_features_to_return.push_back(std::move(neighbor_features));
+    }
+
+    return neighbor_features_to_return;
+  }
 
   ygm::comm&                                           m_comm;
   uint64_t                                             m_rnd_seed;

--- a/include/saltatlas/dnnd/dnnd_advanced.hpp
+++ b/include/saltatlas/dnnd/dnnd_advanced.hpp
@@ -569,6 +569,8 @@ class dnnd {
     return query_result;
   }
 
+  /// TODO: implement query_with_features()
+
   /// \brief Dump the k-NN index to distributed files.
   /// \param out_file_prefix File path prefix.
   /// \param dump_distance If true, also dump distances
@@ -624,12 +626,25 @@ class dnnd {
                    const int source_rank) {
       assert(pthis->contains_local(id));
 
+      // TODO: investigate why point instance is copied in YGM::async() (before
+      // sending apparently).
+      // Because of that, segmentation fault occurs when
+      // Metall is opened as read-only. The below is a workaround to avoid the
+      // issue: Allocate point instance in the heap, not in Metall, explicitly.
+      // If fallback_allocator is used, constructing the point_type without
+      // allocator instance falls back to the default (heap) allocator.
+      point_type point;
+      // TODO: check the value of propagate_on_container_copy_assignment.
+      // Assumes that the propagate_on_container_copy_assignment of the
+      // allocator_type of the point_type is false.
+      point = pthis->get_local_point(id);
+
       comm->async(
           source_rank,
-          [](auto, const auto& id, const auto& point) {
-            return_points_store.emplace(id, point);
+          [](auto, const auto& id, auto point) {
+            return_points_store.emplace(id, std::move(point));
           },
-          id, pthis->get_local_point(id));
+          id, std::move(point));
     };
     m_comm.cf_barrier();
 

--- a/include/saltatlas/dnnd/dnnd_advanced.hpp
+++ b/include/saltatlas/dnnd/dnnd_advanced.hpp
@@ -593,9 +593,53 @@ class dnnd {
   /// \param id Point ID.
   bool contains_local(const id_type id) const { return m_pstore->contains(id); }
 
+  /// \brief Get the owner rank of a point with the given ID.
+  /// \param id Point ID.
+  /// \return The rank that owns the point.
+  int get_owner(const id_type id) const {
+    return priv_get_point_partitioner()(id);
+  }
+
   /// \brief Get a point with the given ID from the local point store.
   const point_type& get_local_point(const id_type id) const {
     return m_pstore->at(id);
+  }
+
+  /// \brief Get point data of the given IDs.
+  /// This function invokes YGM barrier. All ranks must call this function.
+  /// Note: returned data are always stored in normal heap memory, not Metall.
+  template <typename id_iterator>
+  std::unordered_map<id_type, point_type> get_points(
+      id_iterator ids_begin, id_iterator ids_end) const {
+    static_assert(
+        std::is_same_v<typename std::iterator_traits<id_iterator>::value_type,
+                       id_type>,
+        "id_iterator must be an iterator of id_type");
+
+    static std::unordered_map<id_type, point_type> return_points_store;
+    return_points_store = decltype(return_points_store){};
+    return_points_store.reserve(std::distance(ids_begin, ids_end));
+
+    auto proc = [](auto comm, auto pthis, const id_type id,
+                   const int source_rank) {
+      assert(pthis->contains_local(id));
+
+      comm->async(
+          source_rank,
+          [](auto, const auto& id, const auto& point) {
+            return_points_store.emplace(id, point);
+          },
+          id, pthis->get_local_point(id));
+    };
+    m_comm.cf_barrier();
+
+    for (auto it = ids_begin; it != ids_end; ++it) {
+      const auto id = *it;
+      m_comm.async(get_owner(id), proc, m_this, id, m_comm.rank());
+    }
+    m_comm.barrier();
+
+    return return_points_store;
   }
 
   /// \brife Returns an iterator that points to the beginning of the locally
@@ -606,15 +650,137 @@ class dnnd {
   /// points.
   auto local_points_end() const { return m_pstore->end(); }
 
+  /// \brief Get the number of locally stored points.
+  std::size_t num_local_points() const { return m_pstore->size(); }
+
+  /// \brief Get the number of points.
+  /// This function performs an all-reduce operation, which is not cheap.
+  std::size_t num_points() const {
+    return m_comm.all_reduce_sum(m_pstore->size());
+  }
+
   /// \brief API for using 'for_each' with local points.
   iterator_proxy_type local_points() const {
     return iterator_proxy_type(local_points_begin(), local_points_end());
   }
 
   /// \brief Erase a kNN index
-  void erase(const id_type id) {
-    m_knn_index_list->erase(id);
-    m_index_k_list->erase(id);
+  /// \param index_id Index ID.
+  void erase(const std::size_t index_id) {
+    m_knn_index_list->erase(m_knn_index_list->begin() + index_id);
+    m_index_k_list->erase(m_index_k_list->begin() + index_id);
+  }
+
+  /// \brief Get the number of neighbors of the given point.
+  /// If the point is not stored locally, the function returns 0
+  /// \param index_id Index ID.
+  /// \param id Point ID.
+  /// \return The number of neighbors of the point.
+  std::size_t num_local_neighbors(std::size_t   index_id,
+                                  const id_type id) const {
+    if (contains_local(id)) {
+      return m_knn_index_list->at(index_id).at(id).size();
+    }
+    return 0;
+  }
+
+  /// \brief Get the neighbors of the given local point.
+  /// If the point is not stored locally, the function throws an exception.
+  /// \param id Point ID.
+  /// \return The neighbors of the point. A vector of neighbor.
+  std::vector<neighbor_type> get_local_neighbors(std::size_t   index_id,
+                                                 const id_type id) const {
+    std::vector<neighbor_type> neighbors;
+    for (auto itr = m_knn_index_list->at(index_id).neighbors_begin(id),
+              end = m_knn_index_list->at(index_id).neighbors_end(id);
+         itr != end; ++itr) {
+      neighbors.push_back(*itr);
+    }
+    return neighbors;
+  }
+
+  /// \brief Get the neighbors of the given point.
+  /// This function invokes YGM barrier. All ranks must call this function.
+  template <typename id_iterator>
+  std::unordered_map<id_type, std::vector<neighbor_type>> get_neighbors(
+      std::size_t index_id, id_iterator ids_begin, id_iterator ids_end) const {
+    static_assert(
+        std::is_same_v<typename std::iterator_traits<id_iterator>::value_type,
+                       id_type>,
+        "id_iterator must be an iterator of id_type");
+
+    static std::unordered_map<id_type, std::vector<neighbor_type>>
+        neighbors_table;
+    neighbors_table = decltype(neighbors_table){};
+    neighbors_table.reserve(std::distance(ids_begin, ids_end));
+
+    auto proc = [](auto comm, auto pthis, const std::size_t index_id,
+                   const id_type id, const int source_rank) {
+      assert(pthis->contains_local(id));
+      const auto neighbors = pthis->get_local_neighbors(index_id, id);
+      comm->async(
+          source_rank,
+          [](auto, const auto& id, const auto& neighbors) {
+            neighbors_table.emplace(id, neighbors);
+          },
+          id, neighbors);
+    };
+    m_comm.cf_barrier();
+
+    for (auto it = ids_begin; it != ids_end; ++it) {
+      const auto id = *it;
+      m_comm.async(get_owner(id), proc, m_this, index_id, id, m_comm.rank());
+    }
+    m_comm.barrier();
+
+    return neighbors_table;
+  }
+
+  /// \brief Get the neighbors of the given point with features of the
+  /// neighbors.
+  template <typename id_iterator>
+  std::unordered_map<
+      id_type, std::pair<std::vector<neighbor_type>, std::vector<point_type>>>
+  get_neighbors_with_features(std::size_t index_id, id_iterator ids_begin,
+                              id_iterator ids_end) const {
+    // Get neighbors
+    const auto neighbors_table = get_neighbors(index_id, ids_begin, ids_end);
+
+    // Get neighbor's features
+    std::set<id_type> neighbor_ids;
+    for (auto& [id, neighbors] : neighbors_table) {
+      for (const auto& neighbor : neighbors) {
+        neighbor_ids.insert(neighbor.id);
+      }
+    }
+    const auto neighbor_features_table =
+        get_points(neighbor_ids.begin(), neighbor_ids.end());
+
+    // Construct the result table
+    std::unordered_map<
+        id_type, std::pair<std::vector<neighbor_type>, std::vector<point_type>>>
+        result;
+    for (auto& [id, neighbors] : neighbors_table) {
+      std::vector<point_type> neighbor_features;
+      for (const auto& neighbor : neighbors) {
+        neighbor_features.push_back(
+            std::move(neighbor_features_table.at(neighbor.id)));
+      }
+
+      result[id] =
+          std::make_pair(std::move(neighbors), std::move(neighbor_features));
+    }
+    m_comm.cf_barrier();
+
+    return result;
+  }
+
+  std::vector<std::size_t> get_index_ids() const {
+    std::vector<std::size_t> index_ids;
+    for (std::size_t i = 0; i < m_knn_index_list->size(); ++i) {
+      index_ids.push_back(i);
+    }
+    return index_ids;
   }
 
  private:

--- a/include/saltatlas/dnnd/dnnd_simple.hpp
+++ b/include/saltatlas/dnnd/dnnd_simple.hpp
@@ -386,12 +386,9 @@ class dnnd {
                        id_type>,
         "id_iterator must be an iterator of id_type");
 
-    std::unordered_map<id_type, point_type> points;
-    points.reserve(std::distance(ids_begin, ids_end));
-
-    static auto& ref_points = points;
-    ref_points              = points;
-    m_comm.cf_barrier();
+    static std::unordered_map<id_type, point_type> return_points_store;
+    return_points_store.clear();
+    return_points_store.reserve(std::distance(ids_begin, ids_end));
 
     auto proc = [](auto comm, auto pthis, const id_type id,
                    const int source_rank) {
@@ -400,19 +397,19 @@ class dnnd {
       comm->async(
           source_rank,
           [](auto, const auto& id, const auto& point) {
-            ref_points.emplace(id, point);
+            return_points_store.emplace(id, point);
           },
           id, pthis->get_local_point(id));
     };
+    m_comm.cf_barrier();
 
     for (auto it = ids_begin; it != ids_end; ++it) {
       const auto id = *it;
       m_comm.async(get_owner(id), proc, m_this, id, m_comm.rank());
     }
-
     m_comm.barrier();
 
-    return points;
+    return return_points_store;
   }
 
   /// \brife Returns an iterator that points to the beginning of the locally
@@ -472,28 +469,27 @@ class dnnd {
                        id_type>,
         "id_iterator must be an iterator of id_type");
 
-    std::unordered_map<id_type, std::vector<neighbor_type>> neighbors_table;
+    static std::unordered_map<id_type, std::vector<neighbor_type>>
+        neighbors_table;
+    neighbors_table.clear();
     neighbors_table.reserve(std::distance(ids_begin, ids_en));
 
-    static auto& ref_neighbors_table = neighbors_table;
-    ref_neighbors_table              = neighbors_table;
+    auto proc = [](auto comm, auto pthis, const id_type id,
+                   const int source_rank) {
+      assert(pthis->contains_local(id));
+      const auto neighbors = pthis->get_local_neighbors(id);
+      comm->async(
+          source_rank,
+          [](auto, const auto& id, const auto& neighbors) {
+            neighbors_table.emplace(id, neighbors);
+          },
+          id, neighbors);
+    };
     m_comm.cf_barrier();
 
     for (auto it = ids_begin; it != ids_en; ++it) {
       const auto id = *it;
-      m_comm.async(
-          get_owner(id),
-          [](auto comm, auto pthis, const id_type id, const int source_rank) {
-            assert(pthis->contains_local(id));
-            const auto neighbors = pthis->get_local_neighbors(id);
-            comm->async(
-                source_rank,
-                [](auto, const auto& id, const auto& neighbors) {
-                  ref_neighbors_table.emplace(id, neighbors);
-                },
-                id, neighbors);
-          },
-          m_this, id, m_comm.rank());
+      m_comm.async(get_owner(id), proc, m_this, id, m_comm.rank());
     }
     m_comm.barrier();
 

--- a/include/saltatlas/dnnd/dnnd_simple.hpp
+++ b/include/saltatlas/dnnd/dnnd_simple.hpp
@@ -387,7 +387,7 @@ class dnnd {
         "id_iterator must be an iterator of id_type");
 
     static std::unordered_map<id_type, point_type> return_points_store;
-    return_points_store.clear();
+    return_points_store = decltype(return_points_store){};
     return_points_store.reserve(std::distance(ids_begin, ids_end));
 
     auto proc = [](auto comm, auto pthis, const id_type id,
@@ -440,7 +440,7 @@ class dnnd {
   /// \return The number of neighbors of the point.
   std::size_t num_local_neighbors(const id_type id) const {
     if (contains_local(id)) {
-      return m_knn_index.at(id).size();
+      return m_knn_index.num_neighbors(id);
     }
     return 0;
   }
@@ -471,7 +471,7 @@ class dnnd {
 
     static std::unordered_map<id_type, std::vector<neighbor_type>>
         neighbors_table;
-    neighbors_table.clear();
+    neighbors_table = decltype(neighbors_table){};
     neighbors_table.reserve(std::distance(ids_begin, ids_en));
 
     auto proc = [](auto comm, auto pthis, const id_type id,
@@ -494,6 +494,47 @@ class dnnd {
     m_comm.barrier();
 
     return neighbors_table;
+  }
+
+  /// \brief Get the neighbors of the given point with features of the
+  /// neighbors.
+  template <typename id_iterator>
+  std::unordered_map<
+      id_type, std::pair<std::vector<neighbor_type>, std::vector<point_type>>>
+  get_neighbors_with_features(id_iterator ids_begin,
+                              id_iterator ids_end) const {
+    // Get neighbors
+    const auto neighbors_table = get_neighbors(ids_begin, ids_end);
+
+    // Get neighbor's features
+    std::set<id_type> neighbor_ids;
+    for (auto& [id, neighbors] : neighbors_table) {
+      for (const auto& neighbor : neighbors) {
+        neighbor_ids.insert(neighbor.id);
+      }
+    }
+    const auto neighbor_features_table =
+        get_points(neighbor_ids.begin(), neighbor_ids.end());
+
+    // Construct the result table
+    std::unordered_map<
+        id_type, std::pair<std::vector<neighbor_type>, std::vector<point_type>>>
+        result;
+    for (auto& [id, neighbors] : neighbors_table) {
+      result[id];
+
+      std::vector<point_type> neighbor_features;
+      for (const auto& neighbor : neighbors) {
+        neighbor_features.push_back(
+            std::move(neighbor_features_table.at(neighbor.id)));
+      }
+
+      result[id] =
+          std::make_pair(std::move(neighbors), std::move(neighbor_features));
+    }
+    m_comm.cf_barrier();
+
+    return result;
   }
 
  private:

--- a/include/saltatlas/dnnd/dnnd_simple.hpp
+++ b/include/saltatlas/dnnd/dnnd_simple.hpp
@@ -310,6 +310,8 @@ class dnnd {
     return query_result;
   }
 
+  /// \brief Run queries as the same as query() and return the query results
+  /// with the feature vectors of the neighbors.
   template <typename query_iterator>
   std::pair<neighbor_store_type, std::vector<std::vector<point_type>>>
   query_with_features(query_iterator queries_begin, query_iterator queries_end,
@@ -369,28 +371,13 @@ class dnnd {
     return priv_get_point_partitioner()(id);
   }
 
-  /// \brief Get a point with the given ID from the local point store.
+  /// \brief Get a point of the given ID from the local point store.
   const point_type& get_local_point(const id_type id) const {
     return m_pstore.at(id);
   }
 
-  template <typename id_iterator>
-  std::unordered_map<id_type, point_type> get_local_points(
-      id_iterator ids_begin, id_iterator ids_end) const {
-    static_assert(
-        std::is_same_v<typename std::iterator_traits<id_iterator>::value_type,
-                       id_type>,
-        "id_iterator must be an iterator of id_type");
-
-    std::unordered_map<id_type, point_type> points;
-    points.reserve(std::distance(ids_begin, ids_end));
-    for (auto it = ids_begin; it != ids_end; ++it) {
-      const auto id = *it;
-      points.emplace(id, m_pstore.at(id));
-    }
-    return points;
-  }
-
+  /// \brief Get point data of the given IDs.
+  /// This function invokes YGM barrier. All ranks must call this function.
   template <typename id_iterator>
   std::unordered_map<id_type, point_type> get_points(
       id_iterator ids_begin, id_iterator ids_end) const {
@@ -404,6 +391,7 @@ class dnnd {
 
     static auto& ref_points = points;
     ref_points              = points;
+    m_comm.cf_barrier();
 
     auto proc = [](auto comm, auto pthis, const id_type id,
                    const int source_rank) {
@@ -447,6 +435,69 @@ class dnnd {
   /// This function performs an all-reduce operation, which is not cheap.
   std::size_t num_points() const {
     return m_comm.all_reduce_sum(m_pstore.size());
+  }
+
+  /// \brief Get the number of neighbors of the given point.
+  /// If the point is not stored locally, the function returns 0.
+  /// \param id Point ID.
+  /// \return The number of neighbors of the point.
+  std::size_t num_local_neighbors(const id_type id) const {
+    if (contains_local(id)) {
+      return m_knn_index.at(id).size();
+    }
+    return 0;
+  }
+
+  /// \brief Get the neighbors of the given local point.
+  /// If the point is not stored locally, the function throws an exception.
+  /// \param id Point ID.
+  /// \return The neighbors of the point. A vector of neighbor.
+  std::vector<neighbor_type> get_local_neighbors(const id_type id) const {
+    std::vector<neighbor_type> neighbors;
+    for (auto itr = m_knn_index.neighbors_begin(id),
+              end = m_knn_index.neighbors_end(id);
+         itr != end; ++itr) {
+      neighbors.push_back(*itr);
+    }
+    return neighbors;
+  }
+
+  /// \brief Get the neighbors of the given point.
+  /// This function invokes YGM barrier. All ranks must call this function.
+  template <typename id_iterator>
+  std::unordered_map<id_type, std::vector<neighbor_type>> get_neighbors(
+      id_iterator ids_begin, id_iterator ids_en) const {
+    static_assert(
+        std::is_same_v<typename std::iterator_traits<id_iterator>::value_type,
+                       id_type>,
+        "id_iterator must be an iterator of id_type");
+
+    std::unordered_map<id_type, std::vector<neighbor_type>> neighbors_table;
+    neighbors_table.reserve(std::distance(ids_begin, ids_en));
+
+    static auto& ref_neighbors_table = neighbors_table;
+    ref_neighbors_table              = neighbors_table;
+    m_comm.cf_barrier();
+
+    for (auto it = ids_begin; it != ids_en; ++it) {
+      const auto id = *it;
+      m_comm.async(
+          get_owner(id),
+          [](auto comm, auto pthis, const id_type id, const int source_rank) {
+            assert(pthis->contains_local(id));
+            const auto neighbors = pthis->get_local_neighbors(id);
+            comm->async(
+                source_rank,
+                [](auto, const auto& id, const auto& neighbors) {
+                  ref_neighbors_table.emplace(id, neighbors);
+                },
+                id, neighbors);
+          },
+          m_this, id, m_comm.rank());
+    }
+    m_comm.barrier();
+
+    return neighbors_table;
   }
 
  private:

--- a/include/saltatlas/dnnd/feature_vector.hpp
+++ b/include/saltatlas/dnnd/feature_vector.hpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <memory>
+#include <ostream>
 #include "saltatlas/dnnd/detail/utilities/allocator.hpp"
 
 namespace saltatlas {
@@ -42,4 +43,19 @@ template <typename Element,
           typename Allocator = metall::manager::fallback_allocator<Element>>
 using pm_feature_vector = container::vector<Element, Allocator>;
 #endif
+
+// to_string for feature_vector and pm_feature_vector
+template <typename Element, typename Allocator>
+inline std::string to_string(const container::vector<Element, Allocator> &v) {
+  std::ostringstream oss;
+  oss << "[";
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    oss << v[i];
+    if (i + 1 < v.size()) {
+      oss << ", ";
+    }
+  }
+  oss << "]";
+  return oss.str();
+}
 }  // namespace saltatlas


### PR DESCRIPTION
## Overview

- Add `get_neighbors()` and `get_neighbors_with_features()` in both simple and advanced API.
- Updated `dnnd_simple.cpp` to use those new methods.
- Add three executables for advanced API:
  - `dnnd_advance_index_build`: builds KNN index in Metall.
  - `dnnd_advance_get_neighbors`: loads an already built index and calls the new get_neighbor* functions.
  - `dnnd_advance_query`: loads an already built index and runs queries

## Advanced API new examples:

```shell
# Construct k-NN index (k=4).
mpirun -np 2 ./examples/dnnd_advance_index_build -k 4 -f l2 -p wsv ../examples/datasets/point_5-4.txt -d /dev/shm/metall-datastore

# Show neighbors of point 0, 2, and 3 from the k-NN index.
mpirun -np 2 ./examples/dnnd_advance_get_neighbors -d ./dev/shm/metall-datastore -p 0,2,3

# Run queries. Find 4 nearest neighbors per query source point.
mpirun -np 2 ./examples/dnnd_advance_query -d ./dstore/ -f l2 -n 4 -q ../examples/datasets/query_5-4.txt 
```