### PR TITLE
Update YGM utility inclusions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,21 +106,7 @@ if (SALTATLAS_USE_METALL)
     foreach (lib ${BOOST_INCLUDE_LIBRARIES})
         list(APPEND BOOST_FETCHED_COMPONENTS "Boost::${lib}")
     endforeach ()
-else ()
-    FetchContent_Declare(
-        Boost
-        URL https://github.com/boostorg/boost/releases/download/boost-1.87.0/boost-1.87.0-cmake.tar.gz
-    )
-    set(BOOST_INCLUDE_LIBRARIES
-        unordered
-        container
-    )
-    FetchContent_MakeAvailable(Boost)
-    foreach (lib ${BOOST_INCLUDE_LIBRARIES})
-        list(APPEND BOOST_FETCHED_COMPONENTS "Boost::${lib}")
-    endforeach ()
 endif ()
-
 
 #
 # hnswlib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,21 @@ if (SALTATLAS_USE_METALL)
     foreach (lib ${BOOST_INCLUDE_LIBRARIES})
         list(APPEND BOOST_FETCHED_COMPONENTS "Boost::${lib}")
     endforeach ()
+else ()
+    FetchContent_Declare(
+        Boost
+        URL https://github.com/boostorg/boost/releases/download/boost-1.87.0/boost-1.87.0-cmake.tar.gz
+    )
+    set(BOOST_INCLUDE_LIBRARIES
+        unordered
+        container
+    )
+    FetchContent_MakeAvailable(Boost)
+    foreach (lib ${BOOST_INCLUDE_LIBRARIES})
+        list(APPEND BOOST_FETCHED_COMPONENTS "Boost::${lib}")
+    endforeach ()
 endif ()
+
 
 #
 # hnswlib

--- a/examples/dhnsw_bench.cpp
+++ b/examples/dhnsw_bench.cpp
@@ -185,8 +185,8 @@ int main(int argc, char** argv) {
     saltatlas::read_query(opt.query_file_path, queries, world);
 
     world.cout0() << "Executing queries" << std::endl;
-    ygm::timer step_timer;
-    const auto query_results =
+    ygm::utility::timer step_timer;
+    const auto          query_results =
         my_dhnsw.query(queries.begin(), queries.end(), opt.query_k);
     world.cf_barrier();
     world.cout0() << "\nProcessing queries took (s)\t" << step_timer.elapsed()

--- a/examples/dnnd_bench.cpp
+++ b/examples/dnnd_bench.cpp
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
     comm.cout0() << "\n<<Read Points>>" << std::endl;
     const auto paths =
         saltatlas::utility::find_file_paths(opt.point_file_names);
-    ygm::timer point_read_timer;
+    ygm::utility::timer point_read_timer;
     g.load_points(paths.begin(), paths.end(), opt.point_file_format);
     comm.cout0() << "\nReading points took (s)\t" << point_read_timer.elapsed()
                  << std::endl;
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
 
   {
     comm.cout0() << "\n<<kNNG Construction>>" << std::endl;
-    ygm::timer const_timer;
+    ygm::utility::timer const_timer;
     g.build(opt.index_k, opt.r, opt.delta, opt.batch_size);
     comm.cout0() << "\nkNNG construction took (s)\t" << const_timer.elapsed()
                  << std::endl;
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
 
   if (opt.make_index_undirected) {
     comm.cout0() << "\n<<kNNG Optimization>>" << std::endl;
-    ygm::timer optimization_timer;
+    ygm::utility::timer optimization_timer;
     g.optimize(opt.make_index_undirected, opt.pruning_degree_multiplier);
     comm.cout0() << "\nkNNG optimization took (s)\t"
                  << optimization_timer.elapsed() << std::endl;
@@ -119,8 +119,8 @@ int main(int argc, char **argv) {
     saltatlas::read_query(opt.query_file_path, queries, comm);
 
     comm.cout0() << "Executing queries" << std::endl;
-    ygm::timer step_timer;
-    const auto query_results =
+    ygm::utility::timer step_timer;
+    const auto          query_results =
         g.query(queries.begin(), queries.end(), opt.query_k, opt.epsilon);
     comm.cf_barrier();
     comm.cout0() << "\nProcessing queries took (s)\t" << step_timer.elapsed()

--- a/examples/dnnd_example_common.hpp
+++ b/examples/dnnd_example_common.hpp
@@ -16,7 +16,7 @@
 #include <vector>
 
 #include <ygm/comm.hpp>
-#include <ygm/utility.hpp>
+#include <ygm/utility/timer.hpp>
 
 #include <saltatlas/common/data_reader.hpp>
 #include <saltatlas/dnnd/utility.hpp>

--- a/include/saltatlas/dhnsw/detail/metric_hyperplane_partitioner.hpp
+++ b/include/saltatlas/dhnsw/detail/metric_hyperplane_partitioner.hpp
@@ -17,7 +17,7 @@
 
 #include <ygm/comm.hpp>
 #include <ygm/container/map.hpp>
-#include <ygm/utility.hpp>
+#include <ygm/utility/timer.hpp>
 
 namespace saltatlas {
 template <typename DistType, typename IndexType, typename Point>

--- a/include/saltatlas/dhnsw/dhnsw.hpp
+++ b/include/saltatlas/dhnsw/dhnsw.hpp
@@ -151,7 +151,7 @@ class dhnsw {
 
     m_comm.cout0("Repartitioning data");
     m_comm.barrier();
-    ygm::timer t;
+    ygm::utility::timer t;
     repartition_data();
     m_comm.barrier();
     m_comm.cout0("Partitioning time: ", t.elapsed());

--- a/include/saltatlas/dnnd/detail/base_dnnd.hpp
+++ b/include/saltatlas/dnnd/detail/base_dnnd.hpp
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include <ygm/comm.hpp>
-#include <ygm/utility.hpp>
+#include <ygm/utility/timer.hpp>
 
 #include <saltatlas/dnnd/detail/distance.hpp>
 #include <saltatlas/dnnd/detail/dnnd_kernel.hpp>

--- a/include/saltatlas/dnnd/detail/dnnd_kernel.hpp
+++ b/include/saltatlas/dnnd/detail/dnnd_kernel.hpp
@@ -46,7 +46,7 @@
 #endif
 
 #include <ygm/comm.hpp>
-#include <ygm/utility.hpp>
+#include <ygm/utility/timer.hpp>
 
 #include <saltatlas/common/detail/neighbor.hpp>
 #include <saltatlas/common/detail/neighbor_cereal.hpp>
@@ -236,11 +236,11 @@ class dnnd_kernel {
       if (m_option.verbose) {
         m_comm.cout0() << "\n[Epoch\t" << epoch_no << "]" << std::endl;
       }
-      ygm::timer epoch_timer;
+      ygm::utility::timer epoch_timer;
 
-      ygm::timer    gen_timer;
-      adj_lsit_type old_table;
-      adj_lsit_type new_table;
+      ygm::utility::timer gen_timer;
+      adj_lsit_type       old_table;
+      adj_lsit_type       new_table;
       priv_get_old_and_new(old_table, new_table);
       m_comm.cf_barrier();
       if (m_option.verbose) {
@@ -294,7 +294,7 @@ class dnnd_kernel {
   /// This function can accept already partially filled heap.
   void priv_fill_knn_heap_with_random_value() {
     m_comm.cf_barrier();
-    ygm::timer init_timer;
+    ygm::utility::timer init_timer;
 
     // sqrt(k) is enough?
     const std::size_t init_k = m_option.k;
@@ -411,7 +411,7 @@ class dnnd_kernel {
 
   void priv_allocate_knn_heap() {
     m_comm.cf_barrier();
-    ygm::timer timer;
+    ygm::utility::timer timer;
 
     m_knn_heap_table.clear();
 
@@ -828,7 +828,7 @@ class dnnd_kernel {
     if (m_option.verbose) {
       m_comm.cout0() << "\nMini-batch No. " << m_mini_batch_no << std::endl;
     }
-    ygm::timer mini_batch_timer;
+    ygm::utility::timer mini_batch_timer;
 
     const auto local_mini_batch_size = detail::mpi::assign_tasks(
         targets.size(), m_option.mini_batch_size, m_comm.rank(), m_comm.size(),

--- a/include/saltatlas/dnnd/feature_vector.hpp
+++ b/include/saltatlas/dnnd/feature_vector.hpp
@@ -13,7 +13,7 @@
 
 #if SALTATLAS_DNND_USE_METALL_CONTAINER
 #include <metall/container/vector.hpp>
-#include <ygm/detail/cereal_boost_container.hpp>
+#include <ygm/utility/boost_vector.hpp>
 #else
 #include <vector>
 #endif

--- a/utility/dnnd_make_shm_nn_data.cpp
+++ b/utility/dnnd_make_shm_nn_data.cpp
@@ -12,7 +12,7 @@
 #include <metall/container/string.hpp>
 #include <metall/metall.hpp>
 #include <ygm/comm.hpp>
-#include <ygm/utility.hpp>
+#include <ygm/utility/timer.hpp>
 
 #include <saltatlas/dnnd/data_reader.hpp>
 #include <saltatlas/dnnd/dhnsw_index_reader.hpp>
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
     static knn_index_type*           main_knn_index;
     if (comm.rank0()) {
       manager          = std::make_unique<metall::manager>(metall::create_only,
-                                                  out_path.c_str());
+                                                           out_path.c_str());
       main_point_store = manager->construct<point_store_type>(
           metall::unique_instance)(manager->get_allocator());
       main_knn_index = manager->construct<knn_index_type>(


### PR DESCRIPTION
Edited files to use the new YGM updates. Include <ygm/utility/timer.hpp> instead of <ygm/utility.hpp> and include <ygm/utility/boost_vector.hpp> instead of <ygm/detail/cereal_boost_container.hpp>.