### PR TITLE
Update Cmake regarding fetching Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,14 @@ endif ()
 # Controls whether to set up install boilerplate for project and depencencies.
 # Expects CMAKE_INSTALL_PREFIX to be set to a suitable directory.
 option(JUST_INSTALL_SALTATLAS "Skip executables" OFF)
+option(SALTATLAS_USE_HNSWLIB "Use Hnswlib" ON)
 option(SALTATLAS_USE_METALL "Use Metall" OFF)
 option(SALTATLAS_DETERMINISM "Avoid shuffling for deterministic output" OFF)
+# User options to specify Boost source or URL
+set(BOOST_SOURCE_DIR CACHE STRING "Path to Boost libraries directory already uncompressed. Must be a version that supports CMake.")
+set(BOOST_FETCH_URL CACHE STRING "URL or file path to an archived Boost source. Must be a version that supports CMake.")
+# Link Boost UUID with libatomic fails on LC machines
+option(BOOST_UUID_LINK_LIBATOMIC "Link Boost UUID with libatomic" OFF)
 
 # Only do these if this is the main project, and not if it is included through
 # add_subdirectory
@@ -87,38 +93,40 @@ find_package(OpenMP)
 #
 # Boost
 #
-set(FETCHCONTENT_QUIET FALSE)
+include(fetch_boost)
+
+# List of boost components this project depends on
+set(BOOST_COMPS container unordered) # YGM requires these
 if (SALTATLAS_USE_METALL)
-    FetchContent_Declare(
-        Boost
-        URL https://github.com/boostorg/boost/releases/download/boost-1.87.0/boost-1.87.0-cmake.tar.gz
-    )
-    set(BOOST_INCLUDE_LIBRARIES
-        json
-        unordered
-        interprocess
-        container
-        property_tree
-        uuid
-        graph
-    )
-    FetchContent_MakeAvailable(Boost)
-    foreach (lib ${BOOST_INCLUDE_LIBRARIES})
-        list(APPEND BOOST_FETCHED_COMPONENTS "Boost::${lib}")
-    endforeach ()
+    # Metall requires these
+    # Extend BOOST_COMPS
+    list(APPEND BOOST_COMPS json unordered interprocess container property_tree uuid graph)
+endif ()
+
+# We do not check if Boost is already populated, since fetch_boost() does that.
+if (BOOST_SOURCE_DIR)
+  fetch_boost(SOURCE ${BOOST_SOURCE_DIR} COMPONENTS ${BOOST_COMPS})
+elseif (BOOST_FETCH_URL)
+  fetch_boost(URL ${BOOST_FETCH_URL} COMPONENTS ${BOOST_COMPS})
+else ()
+  # Use default Boost version if not specified by the user
+  fetch_boost(URL "https://github.com/boostorg/boost/releases/download/boost-1.88.0/boost-1.88.0-cmake.tar.gz"
+              COMPONENTS ${BOOST_COMPS})
 endif ()
 
 #
 # hnswlib
 #
-# Do not compile any hnswlib tests
-set(JUST_INSTALL_HNSWLIB ON)
-FetchContent_Declare(
-    hnswlib
-    GIT_REPOSITORY https://github.com/bwpriest/hnswlib.git
-    GIT_TAG feature/cmake_facelift
-)
-FetchContent_MakeAvailable(hnswlib)
+if (SALTATLAS_USE_HNSWLIB)
+    # Do not compile any hnswlib tests
+    set(JUST_INSTALL_HNSWLIB ON)
+    FetchContent_Declare(
+        hnswlib
+        GIT_REPOSITORY https://github.com/bwpriest/hnswlib.git
+        GIT_TAG feature/cmake_facelift
+    )
+    FetchContent_MakeAvailable(hnswlib)
+endif ()
 
 #
 # Cereal
@@ -142,6 +150,9 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(ygm)
 
+#
+# SALTATLAS INTERFACE
+#
 add_library(saltatlas INTERFACE)
 add_library(saltatlas::saltatlas ALIAS saltatlas)
 target_compile_features(saltatlas INTERFACE cxx_std_20)
@@ -150,8 +161,11 @@ target_include_directories(
                         $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(
-    saltatlas INTERFACE ${SALTATLAS_CEREAL_TARGET} ygm::ygm hnswlib::hnswlib
+    saltatlas INTERFACE ${SALTATLAS_CEREAL_TARGET} ygm::ygm ${BOOST_LIBS}
 )
+if (SALTATLAS_USE_HNSWLIB)
+    target_link_libraries(saltatlas INTERFACE hnswlib::hnswlib)
+endif ()
 if (SALTATLAS_DETERMINISM)
     message(STATUS ${PROJECT_NAME} " setting determinism")
     target_compile_definitions(saltatlas INTERFACE SALTATLAS_DETERMINISM)
@@ -171,8 +185,6 @@ if (SALTATLAS_USE_METALL)
 
     find_package(Threads REQUIRED)
     target_link_libraries(saltatlas INTERFACE Threads::Threads Metall::Metall)
-
-    target_link_libraries(saltatlas INTERFACE ${BOOST_FETCHED_COMPONENTS})
 endif ()
 
 if (JUST_INSTALL_SALTATLAS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ cmake_minimum_required(VERSION 3.14)
 # ---------------------------------------------------------------------------- #
 # CMake policy
 # ---------------------------------------------------------------------------- #
+# When using the URL download method with the ExternalProject_Add() or
+# FetchContent_Declare() commands, sets the timestamps of extracted contents
+# to the time of extraction.
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW)
+endif ()
+
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.30")
     cmake_policy(SET CMP0167 NEW)
 endif ()

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ Instructions for each method will be provided.
 
 ### Generic steps
 These are the generic steps in install saltatlas.
-saltalas's build system will automatically fetch all dependencies, including
-boost if using the cmake flag `-DSALTATLAS_USE_METALL=ON` (this is off by
-default).
+saltalas's build system will automatically fetch all dependencies.
+
 ``` bash
 # Load an appropriate version of gcc (on LC systems)
 module load gcc/12.1.1-magic
@@ -17,6 +16,21 @@ cmake .. -DCMAKE_BUILD_TYPE=Release
 # Builds all compile targets
 make -j
 ```
+
+#### Fetching Boost
+
+saltatlas's CMake will automatically fetch a proper version of Boost by default.
+
+There are two CMake options to change the behavior:
+
+- `BOOST_SOURCE_DIR`
+  - Path to Boost libraries directory already downloaded and uncompressed.
+  - This option will copy the only required files to build this project from the original source directory. Useful for faster build and saving disk space.
+- `BOOST_FETCH_URL`
+  - URL or file path to an archived Boost source.
+
+For both cases, Boost must be a version that supports CMake.
+Using two options at the same time will result in an error.
 
 ## Running examples
 

--- a/cmake/fetch_boost.cmake
+++ b/cmake/fetch_boost.cmake
@@ -1,0 +1,77 @@
+include(FetchContent)
+include(CMakeParseArguments)
+
+function(fetch_boost_url boost_url)
+    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25")
+        FetchContent_Declare(Boost URL "${boost_url}" SYSTEM)
+    else ()
+        FetchContent_Declare(Boost URL "${boost_url}")
+    endif ()
+    FetchContent_MakeAvailable(Boost)
+endfunction()
+
+function(fetch_boost_source boost_source)
+    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25")
+        FetchContent_Declare(Boost SOURCE_DIR "${boost_source}" SYSTEM)
+    else ()
+        FetchContent_Declare(Boost SOURCE_DIR "${boost_source}")
+    endif ()
+    FetchContent_MakeAvailable(Boost)
+endfunction()
+
+# Fetch Boost libraries using FetchContent.
+# Check if Boost is already available using FetchContent first.
+# If not, fetch Boost based on the provided SOURCE or URL.
+# Arguments:
+#   Required:
+#       COMPONENTS - List of Boost components to include (e.g., filesystem, system)
+#   Optional:
+#      SOURCE - Path to Boost libraries directory already uncompressed. Must be a version that supports CMake.
+#       URL - URL or file path to an archived Boost source. Must be a version that supports CMake.
+# Output:
+#   BOOST_LIBS - List of Boost components to link using link_libraries() or target_link_libraries()
+function(fetch_boost)
+    # Add a prefix ('fetch_boost') to the messages.
+    # To show prefix, set CMAKE_MESSAGE_CONTEXT to true.
+    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17")
+        list(APPEND CMAKE_MESSAGE_CONTEXT "fetch_boost")
+    endif ()
+
+    # Unset input variables to avoid interference
+    unset(__fetch_boost_COMPONENTS)
+    unset(__fetch_boost_SOURCE)
+    unset(__fetch_boost_URL)
+
+    cmake_parse_arguments(__fetch_boost "" "URL;SOURCE" "COMPONENTS" ${ARGV})
+
+    if (__fetch_boost_URL AND __fetch_boost_SOURCE)
+        message(FATAL_ERROR "Both SOURCE and URL arguments cannot be set at the same time")
+    endif ()
+
+    # Boost's CMake uses BOOST_INCLUDE_LIBRARIES to specify the components to include.
+    set(BOOST_INCLUDE_LIBRARIES ${__fetch_boost_COMPONENTS})
+
+    if (boost_POPULATED)
+        # Boost is already available by FetchContent.
+        message(VERBOSE "Boost was already populated")
+        # This is likely not required. We do this just in case.
+        fetch_boost_url("https://github.com/boostorg/boost/releases/download/boost-1.87.0/boost-1.87.0-cmake.tar.gz")
+    elseif (__fetch_boost_SOURCE)
+        message(VERBOSE "Will fetch Boost source from ${__fetch_boost_SOURCE}")
+        fetch_boost_source(${__fetch_boost_SOURCE})
+    elseif (__fetch_boost_URL)
+        message(VERBOSE "Will fetch Boost from ${__fetch_boost_URL}")
+        fetch_boost_url(${__fetch_boost_URL})
+    else ()
+        message(WARNING "Boost was not populated or fetched")
+        unset(BOOST_LIBS)
+        return()
+    endif ()
+
+    # Boost Components to link
+    foreach(lib IN LISTS BOOST_INCLUDE_LIBRARIES)
+        list(APPEND BOOST_LIBS "Boost::${lib}")
+    endforeach ()
+    set(BOOST_LIBS ${BOOST_LIBS} PARENT_SCOPE)
+
+endfunction()


### PR DESCRIPTION
I brushed up on CMake file regarding fetching Boost.

Currently, saltatlas's CMake fetches Boost from the hard-coded URL.

This PR version still fetches a proper version of Boost automatically by default (thus, no changes are required in other projects that use saltatlas).
I added two CMake options to change the behavior as follows:

- `BOOST_SOURCE_DIR`
  - Path to Boost libraries directory already downloaded and uncompressed.
  - This option will copy the only required files to build this project from the original source directory. Useful for faster build and saving disk space.
- `BOOST_FETCH_URL`
  - URL or file path to an archived Boost source.

For both cases, Boost must be a version that supports CMake.
Using two options at the same time will result in an error.