### PR TITLE
Expose recheck bool to dnnd advanced; small fix to print out of # random neighbors

### DIFF
--- a/include/saltatlas/dnnd/detail/dnnd_kernel.hpp
+++ b/include/saltatlas/dnnd/detail/dnnd_kernel.hpp
@@ -357,7 +357,7 @@ class dnnd_kernel {
       m_comm.cout0() << "Filling initial index took (s)\t"
                      << init_timer.elapsed() << std::endl;
       m_comm.cout0() << "#of generated initial neighbors: "
-                     << ygm::sum(num_random_neighbors) << std::endl;
+                     << ygm::sum(num_random_neighbors, m_comm) << std::endl;
     }
   }
 

--- a/include/saltatlas/dnnd/detail/dnnd_kernel.hpp
+++ b/include/saltatlas/dnnd/detail/dnnd_kernel.hpp
@@ -358,9 +358,16 @@ class dnnd_kernel {
     if (m_option.verbose) {
       m_comm.cout0() << "Filling initial index took (s)\t"
                      << init_timer.elapsed() << std::endl;
-      m_comm.cout0() << "#of generated initial neighbors: "
-                     << m_comm.all_reduce_sum(num_random_neighbors)
-                     << std::endl;
+      if (m_comm.all_reduce_sum(num_random_neighbors) > 0) {
+        m_comm.cout0() << "#of generated initial neighbors: "
+                       << m_comm.all_reduce_sum(num_random_neighbors)
+                       << std::endl;
+      } else {
+        m_comm.cout0() << "#of generated initial neighbors: "
+                       << m_comm.all_reduce_sum(m_knn_heap_table.size() *
+                                                init_k)
+                       << std::endl;
+      }
     }
   }
 

--- a/include/saltatlas/dnnd/detail/dnnd_kernel.hpp
+++ b/include/saltatlas/dnnd/detail/dnnd_kernel.hpp
@@ -300,8 +300,9 @@ class dnnd_kernel {
     // sqrt(k) is enough?
     const std::size_t init_k = m_option.k;
 
-    // Keep track of number of random neighbros generated
-    static std::size_t num_random_neighbors = 0;
+    // Keep track of number of random neighbors generated
+    static std::size_t num_random_neighbors;
+    num_random_neighbors = 0;
 
     // Initialize the k-nn heap with random values using a batched algorithm to
     // avoid sending too many messages at once. A single task corresponds to all
@@ -328,10 +329,6 @@ class dnnd_kernel {
             }
           }
 
-          if (0 < neighbors.size() && neighbors.size() < init_k) {
-            num_random_neighbors += init_k - neighbors.size();
-          }
-
           // Fill the remaining space with random values
           while (neighbors.size() < init_k) {
             id_type nid;
@@ -345,6 +342,7 @@ class dnnd_kernel {
             }
 
             neighbors.insert(nid);
+            ++num_random_neighbors;
             // Visit 'nid' and come back to 'sid' with the distance between
             // them.
             m_comm.async(m_point_partitioner(nid), distance_calculator{},
@@ -358,15 +356,8 @@ class dnnd_kernel {
     if (m_option.verbose) {
       m_comm.cout0() << "Filling initial index took (s)\t"
                      << init_timer.elapsed() << std::endl;
-      if (m_comm.all_reduce_sum(num_random_neighbors) > 0) {
-        m_comm.cout0() << "#of generated initial neighbors: "
-                       << m_comm.all_reduce_sum(num_random_neighbors)
-                       << std::endl;
-      } else {
-        m_comm.cout0() << "#of generated initial neighbors: "
-                       << ygm::sum(m_knn_heap_table.size() * init_k, m_comm)
-                       << std::endl;
-      }
+      m_comm.cout0() << "#of generated initial neighbors: "
+                     << ygm::sum(num_random_neighbors) << std::endl;
     }
   }
 

--- a/include/saltatlas/dnnd/detail/dnnd_kernel.hpp
+++ b/include/saltatlas/dnnd/detail/dnnd_kernel.hpp
@@ -364,8 +364,7 @@ class dnnd_kernel {
                        << std::endl;
       } else {
         m_comm.cout0() << "#of generated initial neighbors: "
-                       << m_comm.all_reduce_sum(m_knn_heap_table.size() *
-                                                init_k)
+                       << ygm::sum(m_knn_heap_table.size() * init_k, m_comm)
                        << std::endl;
       }
     }

--- a/include/saltatlas/dnnd/detail/dnnd_kernel.hpp
+++ b/include/saltatlas/dnnd/detail/dnnd_kernel.hpp
@@ -299,6 +299,9 @@ class dnnd_kernel {
     // sqrt(k) is enough?
     const std::size_t init_k = m_option.k;
 
+    // Keep track of number of random neighbros generated
+    static std::size_t num_random_neighbors = 0;
+
     // Initialize the k-nn heap with random values using a batched algorithm to
     // avoid sending too many messages at once. A single task corresponds to all
     // works of a single point in the dataset to simplify the implementation.
@@ -322,6 +325,10 @@ class dnnd_kernel {
               const auto& nid = nitr->first;
               neighbors.insert(nid);
             }
+          }
+
+          if (0 < neighbors.size() && neighbors.size() < init_k) {
+            num_random_neighbors += init_k - neighbors.size();
           }
 
           // Fill the remaining space with random values
@@ -351,7 +358,7 @@ class dnnd_kernel {
       m_comm.cout0() << "Filling initial index took (s)\t"
                      << init_timer.elapsed() << std::endl;
       m_comm.cout0() << "#of generated initial neighbors: "
-                     << m_comm.all_reduce_sum(m_knn_heap_table.size() * init_k)
+                     << m_comm.all_reduce_sum(num_random_neighbors)
                      << std::endl;
     }
   }

--- a/include/saltatlas/dnnd/dnnd_advanced.hpp
+++ b/include/saltatlas/dnnd/dnnd_advanced.hpp
@@ -316,10 +316,10 @@ class dnnd {
   /// \param delta Delta parameter in NN-Descent.
   std::size_t build(const distance::id& distance_func_id, const int k,
                     const knn_index_type& initial_index, const double rho = 0.8,
-                    const double delta = 0.001) {
+                    const double delta = 0.001, const bool recheck = false) {
     return build(distance::distance_function<point_type, distance_type>(
                      distance_func_id),
-                 k, initial_index, rho, delta);
+                 k, initial_index, rho, delta, recheck);
   }
 
   /// \brief Build a KNNG.
@@ -332,7 +332,7 @@ class dnnd {
   /// \param delta Delta parameter in NN-Descent.
   std::size_t build(distance_function_type dfunc, const int k,
                     const knn_index_type& initial_index, const double rho = 0.8,
-                    const double delta = 0.001) {
+                    const double delta = 0.001, const bool recheck = false) {
     typename nn_kernel_type::option option{.k                          = k,
                                            .r                          = rho,
                                            .delta                      = delta,
@@ -344,7 +344,7 @@ class dnnd {
     nn_kernel_type kernel(option, *m_pstore, priv_get_point_partitioner(),
                           dfunc, m_comm);
     m_knn_index_list->emplace_back();
-    kernel.construct(initial_index, false, m_knn_index_list->back());
+    kernel.construct(initial_index, recheck, m_knn_index_list->back());
     m_index_k_list->push_back(k);
 
     return m_knn_index_list->size() - 1;
@@ -360,10 +360,11 @@ class dnnd {
   std::size_t build(
       const distance::id& distance_func_id, const int k,
       const std::unordered_map<id_type, std::vector<id_type>>& initial_index,
-      const double rho = 0.8, const double delta = 0.001) {
+      const double rho = 0.8, const double delta = 0.001,
+      const bool recheck = false) {
     return build(distance::distance_function<point_type, distance_type>(
                      distance_func_id),
-                 k, initial_index, rho, delta);
+                 k, initial_index, rho, delta, recheck);
   }
 
   /// \brief Build a KNNG.
@@ -376,7 +377,8 @@ class dnnd {
   std::size_t build(
       distance_function_type dfunc, const int k,
       const std::unordered_map<id_type, std::vector<id_type>>& initial_index,
-      const double rho = 0.8, const double delta = 0.001) {
+      const double rho = 0.8, const double delta = 0.001,
+      const bool recheck = false) {
     typename nn_kernel_type::option option{.k                          = k,
                                            .r                          = rho,
                                            .delta                      = delta,
@@ -388,7 +390,7 @@ class dnnd {
     nn_kernel_type kernel(option, *m_pstore, priv_get_point_partitioner(),
                           dfunc, m_comm);
     m_knn_index_list->emplace_back();
-    kernel.construct(initial_index, false, m_knn_index_list->back());
+    kernel.construct(initial_index, recheck, m_knn_index_list->back());
     m_index_k_list->push_back(k);
 
     return m_knn_index_list->size() - 1;


### PR DESCRIPTION
Expose dnnd_kernel.construct recheck variable so that it can be modified in the build function of dnnd_advanced.

Modify the priv_fill_knn_heap_with_random_value() function in dnnd_kernel so that if an initial index was provided, we track the actual number of random neighbors generated and print that out