### PR TITLE
Enabling Verbose Mode in String Examples

### DIFF
--- a/examples/dnnd_simple_charhist.cpp
+++ b/examples/dnnd_simple_charhist.cpp
@@ -60,6 +60,9 @@ struct option_t {
   int    query_k{1};  // #of neighbors to search for
   double epsilon{0.1};
 
+  // RNG seed
+  uint64_t rng_seed = std::random_device{}();
+
   // Data dump options
   std::filesystem::path index_dump_prefix;
   bool                  dump_index_with_distance{false};
@@ -94,7 +97,8 @@ int main(int argc, char **argv) {
     return 0;
   }
 
-  saltatlas::dnnd<id_t, point_type, dist_t> g(char_histgram_distance, comm);
+  saltatlas::dnnd<id_t, point_type, dist_t> g(char_histgram_distance, comm,
+                                              opt.rng_seed, opt.verbose);
 
   comm.cout0() << "<<Read Points>>" << std::endl;
   // Read string points, where each line in files is a string
@@ -145,7 +149,7 @@ bool parse_options(int argc, char **argv, option_t &opt, bool &help) {
   help = false;
 
   int n;
-  while ((n = ::getopt(argc, argv, "k:r:d:f:p:um:e:q:n:g:o:b:G:Dvh")) != -1) {
+  while ((n = ::getopt(argc, argv, "k:r:d:f:p:um:e:q:n:g:o:b:G:Ds:vh")) != -1) {
     switch (n) {
       case 'k':
         opt.index_k = std::stoi(optarg);
@@ -201,6 +205,10 @@ bool parse_options(int argc, char **argv, option_t &opt, bool &help) {
 
       case 'D':
         opt.dump_index_with_distance = true;
+        break;
+
+      case 's':
+        opt.rng_seed = std::stoull(optarg);
         break;
 
       case 'v':

--- a/examples/dnnd_simple_levenshtein.cpp
+++ b/examples/dnnd_simple_levenshtein.cpp
@@ -42,6 +42,9 @@ struct option_t {
   int    query_k{1};  // #of neighbors to search for
   double epsilon{0.1};
 
+  // RNG seed
+  uint64_t rng_seed = std::random_device{}();
+
   // Data dump options
   std::filesystem::path index_dump_prefix;
   bool                  dump_index_with_distance{false};
@@ -77,7 +80,7 @@ int main(int argc, char **argv) {
   }
 
   saltatlas::dnnd<id_t, point_type, dist_t> g(
-      saltatlas::distance::id::levenshtein, comm);
+      saltatlas::distance::id::levenshtein, comm, opt.rng_seed, opt.verbose);
 
   comm.cout0() << "<<Read Points>>" << std::endl;
   // Read string points, where each line in files is a string
@@ -128,7 +131,7 @@ bool parse_options(int argc, char **argv, option_t &opt, bool &help) {
   help = false;
 
   int n;
-  while ((n = ::getopt(argc, argv, "k:r:d:f:p:um:e:q:n:g:o:b:G:Dvh")) != -1) {
+  while ((n = ::getopt(argc, argv, "k:r:d:f:p:um:e:q:n:g:o:b:G:Ds:vh")) != -1) {
     switch (n) {
       case 'k':
         opt.index_k = std::stoi(optarg);
@@ -184,6 +187,10 @@ bool parse_options(int argc, char **argv, option_t &opt, bool &help) {
 
       case 'D':
         opt.dump_index_with_distance = true;
+        break;
+
+      case 's':
+        opt.rng_seed = std::stoull(optarg);
         break;
 
       case 'v':

--- a/examples/dnnd_simple_levenshtein_utf8.cpp
+++ b/examples/dnnd_simple_levenshtein_utf8.cpp
@@ -44,6 +44,9 @@ struct option_t {
   int    query_k{1};  // #of neighbors to search for
   double epsilon{0.1};
 
+  // RNG seed
+  uint64_t rng_seed = std::random_device{}();
+
   // Data dump options
   std::filesystem::path index_dump_prefix;
   bool                  dump_index_with_distance{false};
@@ -87,7 +90,8 @@ int main(int argc, char **argv) {
     return saltatlas::distance::levenshtein<std::u32string, dist_t>(a32, b32);
   };
 
-  saltatlas::dnnd<id_t, point_type, dist_t> g(levenshtein_utf8, comm);
+  saltatlas::dnnd<id_t, point_type, dist_t> g(levenshtein_utf8, comm,
+                                              opt.rng_seed, opt.verbose);
 
   comm.cout0() << "<<Read Points>>" << std::endl;
   // Read string points, where each line in files is a string
@@ -139,7 +143,7 @@ bool parse_options(int argc, char **argv, option_t &opt, bool &help) {
   help = false;
 
   int n;
-  while ((n = ::getopt(argc, argv, "k:r:d:f:p:um:e:q:n:g:o:b:G:Dvh")) != -1) {
+  while ((n = ::getopt(argc, argv, "k:r:d:f:p:um:e:q:n:g:o:b:G:Ds:vh")) != -1) {
     switch (n) {
       case 'k':
         opt.index_k = std::stoi(optarg);
@@ -195,6 +199,10 @@ bool parse_options(int argc, char **argv, option_t &opt, bool &help) {
 
       case 'D':
         opt.dump_index_with_distance = true;
+        break;
+
+      case 's':
+        opt.rng_seed = std::stoull(optarg);
         break;
 
       case 'v':


### PR DESCRIPTION
Adds option to set RNG seed in string examples of DNND and passes that and the verbose flag to the underlying DNND class to give verbose output when asked